### PR TITLE
action-view interoperability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: run tests
           command: |
             mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/usage/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            TEST_FILES="$(circleci tests glob "spec/usage/**/*_spec.rb" "spec/matestack/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
             bundle exec rspec --format progress \
                             --out /tmp/test-results/rspec.xml \

--- a/app/concepts/matestack/ui/core/component/dynamic.rb
+++ b/app/concepts/matestack/ui/core/component/dynamic.rb
@@ -4,6 +4,7 @@ module Matestack::Ui::Core::Component
     include ::Cell::Haml
     include Matestack::Ui::Core::ApplicationHelper
     include Matestack::Ui::Core::ToCell
+    include Matestack::Ui::Core::HasViewContext
 
     view_paths << "#{Matestack::Ui::Core::Engine.root}/app/concepts"
     view_paths << "#{::Rails.root}/app/matestack"

--- a/app/concepts/matestack/ui/core/page/page.rb
+++ b/app/concepts/matestack/ui/core/page/page.rb
@@ -5,6 +5,7 @@ module Matestack::Ui::Core::Page
     include ::Cell::Haml
     include Matestack::Ui::Core::ApplicationHelper
     include Matestack::Ui::Core::ToCell
+    include Matestack::Ui::Core::HasViewContext
 
     view_paths << "#{Matestack::Ui::Core::Engine.root}/app/concepts"
 

--- a/app/helpers/matestack/ui/core/application_helper.rb
+++ b/app/helpers/matestack/ui/core/application_helper.rb
@@ -2,6 +2,7 @@ module Matestack
   module Ui
     module Core
       module ApplicationHelper
+        include Matestack::Ui::Core::Render
 
         def render_page(page_class, only_page=false)
           page_class.new(nil, context: {

--- a/app/helpers/matestack/ui/core/application_helper.rb
+++ b/app/helpers/matestack/ui/core/application_helper.rb
@@ -6,7 +6,8 @@ module Matestack
         def render_page(page_class, only_page=false)
           page_class.new(nil, context: {
             params: params,
-            request: request
+            request: request,
+            view_context: view_context
           }, controller_instance: self).call(:show, nil, only_page)
         end
 

--- a/app/lib/matestack/ui/core/component_node.rb
+++ b/app/lib/matestack/ui/core/component_node.rb
@@ -21,7 +21,11 @@ module Matestack::Ui::Core
 
     def method_missing meth, *args, &block
       begin
-        @component_instance.send(meth, *args, &block)
+        if (result = @component_instance.send(meth, *args, &block)).kind_of? ActiveSupport::SafeBuffer
+          plain result
+        else
+          result
+        end
       rescue
         node_id = @node_start_id + 1
         @node_start_id = node_id

--- a/app/lib/matestack/ui/core/has_view_context.rb
+++ b/app/lib/matestack/ui/core/has_view_context.rb
@@ -1,0 +1,10 @@
+module Matestack::Ui::Core::HasViewContext
+  def initialize(model = nil, options = {})
+    @view_context = options[:context][:view_context]
+    super
+  end
+
+  def method_missing(*args, &block)
+    @view_context.send(*args, &block)
+  end
+end

--- a/app/lib/matestack/ui/core/page_node.rb
+++ b/app/lib/matestack/ui/core/page_node.rb
@@ -22,7 +22,11 @@ module Matestack::Ui::Core
 
     def method_missing meth, *args, &block
       begin
-        @page_instance.send(meth, *args, &block)
+        if (result = @page_instance.send(meth, *args, &block)).kind_of? ActiveSupport::SafeBuffer
+          plain result
+        else
+          result
+        end
       rescue
         node_id = @node_start_id + 1
         @node_start_id = node_id

--- a/app/lib/matestack/ui/core/render.rb
+++ b/app/lib/matestack/ui/core/render.rb
@@ -1,0 +1,25 @@
+module Matestack::Ui::Core::Render
+
+  # Matestack allows you to use `render` to render matestack pages.
+  #
+  #     render Pages::Member::Bookings
+  #     render matestack: Pages::Member::Bookings
+  #     render matestack: 'member/bookings'
+  #
+  def render(*args)
+    if (matestack_class = args.first).is_a?(Class) && (matestack_class < Matestack::Ui::Page)
+      responder_for matestack_class
+    elsif (options = args.first).kind_of?(Hash) && (matestack_arg = options[:matestack]).present?
+      if (matestack_path = matestack_arg).kind_of? String
+        matestack_path = "pages/#{matestack_path}" unless matestack_path.start_with?("pages/") or matestack_path.start_with?("components/")
+        matestack_class = matestack_path.split("/").collect { |str| str.camelcase }.join("::").constantize
+      elsif matestack_arg.is_a?(Class) && (matestack_arg < Matestack::Ui::Page)
+        matestack_class = matestack_arg
+      end
+      responder_for matestack_class
+    else
+      super
+    end
+  end
+
+end

--- a/app/lib/matestack/ui/core/render.rb
+++ b/app/lib/matestack/ui/core/render.rb
@@ -40,8 +40,20 @@ module Matestack::Ui::Core::Render
   # In this example, `clients/bookings#index` will render `Pages::Clients::Bookings`,
   # `clients/bookings#show` will render `Pages::Clients::Booking`.
   #
+  # Custom action names translate also into page names.
+  #
+  #     class Clients::BookingsController < ApplicationController
+  #       def step1
+  #       end
+  #     end
+  #
+  # In this example, the `clients/bookings#step1` action will render
+  # `Pages::Clients::Bookings::Step1`.
+  #
   def default_render(*args)
-    matestack_class_name_parts = "pages/#{controller_path}".split("/").collect { |str| str.camelcase }
+    matestack_page_path = "pages/#{controller_path}"
+    matestack_page_path = "#{matestack_page_path}/#{action_name}" unless action_name.in? %w(index show)
+    matestack_class_name_parts = matestack_page_path.split("/").collect { |str| str.camelcase }
     matestack_class_name_parts[-1] = matestack_class_name_parts[-1].singularize if action_name == "show"
     matestack_class_name = matestack_class_name_parts.join("::")
     begin

--- a/app/lib/matestack/ui/core/render.rb
+++ b/app/lib/matestack/ui/core/render.rb
@@ -22,4 +22,37 @@ module Matestack::Ui::Core::Render
     end
   end
 
+  # Matestack allows implicit rendering. When an `index` or `show` action is requested, which is not
+  # defined, then the matestack page is inferred from the controller name. The index action will
+  # look for a `Page` with a plural name, the show action will look for a `Page` with a singular
+  # name.
+  #
+  #     class Clients::BookingsController < ApplicationController
+  #       def index
+  #         @bookings = Booking.all
+  #       end
+  #
+  #       def show
+  #         @booking = Booking.find params[:id]
+  #       end
+  #     end
+  #
+  # In this example, `clients/bookings#index` will render `Pages::Clients::Bookings`,
+  # `clients/bookings#show` will render `Pages::Clients::Booking`.
+  #
+  def default_render(*args)
+    matestack_class_name_parts = "pages/#{controller_path}".split("/").collect { |str| str.camelcase }
+    matestack_class_name_parts[-1] = matestack_class_name_parts[-1].singularize if action_name == "show"
+    matestack_class_name = matestack_class_name_parts.join("::")
+    begin
+      matestack_class = matestack_class_name.constantize
+    rescue NameError
+    end
+    if matestack_class
+      render matestack: matestack_class
+    else
+      super
+    end
+  end
+
 end

--- a/app/lib/matestack/ui/core/render.rb
+++ b/app/lib/matestack/ui/core/render.rb
@@ -22,18 +22,18 @@ module Matestack::Ui::Core::Render
     end
   end
 
-  # Matestack allows implicit rendering. When an `index` or `show` action is requested, which is not
-  # defined, then the matestack page is inferred from the controller name. The index action will
-  # look for a `Page` with a plural name, the show action will look for a `Page` with a singular
-  # name.
+  # Matestack allows implicit rendering. The matestack page class name is inferred from the
+  # controller path and action name.
   #
   #     class Clients::BookingsController < ApplicationController
   #       def index
   #         @bookings = Booking.all
+  #         # looks for Pages::Clients::Bookings::Index
   #       end
   #
   #       def show
   #         @booking = Booking.find params[:id]
+  #         # looks for Pages::Clients::Bookings::Show
   #       end
   #     end
   #
@@ -44,6 +44,7 @@ module Matestack::Ui::Core::Render
   #
   #     class Clients::BookingsController < ApplicationController
   #       def step1
+  #         # looks for Pages::Clients::Bookings::Step1
   #       end
   #     end
   #

--- a/spec/matestack/ui/core/renderer_spec.rb
+++ b/spec/matestack/ui/core/renderer_spec.rb
@@ -94,5 +94,51 @@ describe Matestack::Ui::Core::Render do
       end
     end
 
+    describe "implicit rendering for custom actions", type: :feature, js: true do
+      before do
+        module Clients
+        end
+
+        class Clients::BookingsController < ApplicationController
+          include Matestack::Ui::Core::ApplicationHelper
+
+          def step1
+          end
+        end
+
+        Rails.application.routes.draw do
+          namespace :clients do
+            get 'bookings/step1', to: 'bookings#step1'
+          end
+        end
+
+        class Apps::Clients < Matestack::Ui::App
+          def response
+            components {
+              page_content
+            }
+          end
+        end
+
+        module Pages::Clients
+        end
+
+        class Pages::Clients::Bookings::Step1 < Matestack::Ui::Page
+          def response
+            components {
+              plain "Hello from the Pages::Clients::Bookings::Step1 page."
+            }
+          end
+        end
+      end
+      after do
+        Rails.application.reload_routes!
+      end
+      specify do
+        visit "/clients/bookings/step1"
+        expect(page).to have_text "Hello from the Pages::Clients::Bookings::Step1 page."
+      end
+    end
+
   end
 end

--- a/spec/matestack/ui/core/renderer_spec.rb
+++ b/spec/matestack/ui/core/renderer_spec.rb
@@ -40,10 +40,58 @@ describe Matestack::Ui::Core::Render do
       end
       after do
         Rails.application.reload_routes!
+        Pages::Clients.send :remove_const, :Bookings
       end
       specify do
         visit "/clients/bookings"
         expect(page).to have_text "Hello from the Pages::Clients::Bookings page."
+      end
+    end
+
+    describe "implicit rendering for index actions with explicit index page name", type: :feature, js: true do
+      before do
+        module Clients
+        end
+
+        class Clients::BookingsController < ApplicationController
+          include Matestack::Ui::Core::ApplicationHelper
+
+          def index
+          end
+        end
+
+        Rails.application.routes.draw do
+          namespace :clients do
+            resources :bookings
+          end
+        end
+
+        class Apps::Clients < Matestack::Ui::App
+          def response
+            components {
+              page_content
+            }
+          end
+        end
+
+        module Pages::Clients::Bookings
+        end
+
+        class Pages::Clients::Bookings::Index < Matestack::Ui::Page
+          def response
+            components {
+              plain "Hello from the Pages::Clients::Bookings::Index page."
+            }
+          end
+        end
+      end
+      after do
+        Rails.application.reload_routes!
+        Pages::Clients.send :remove_const, :Bookings
+      end
+      specify do
+        visit "/clients/bookings"
+        expect(page).to have_text "Hello from the Pages::Clients::Bookings::Index page."
       end
     end
 
@@ -87,10 +135,59 @@ describe Matestack::Ui::Core::Render do
       end
       after do
         Rails.application.reload_routes!
+        Pages::Clients.send :remove_const, :Booking
       end
       specify do
         visit "/clients/bookings/123"
         expect(page).to have_text "Hello from the Pages::Clients::Booking page with id 123."
+      end
+    end
+
+    describe "implicit rendering for show actions with explicit show page name", type: :feature, js: true do
+      before do
+        module Clients
+        end
+
+        class Clients::BookingsController < ApplicationController
+          include Matestack::Ui::Core::ApplicationHelper
+
+          def show
+            @id = params[:id]
+          end
+        end
+
+        Rails.application.routes.draw do
+          namespace :clients do
+            resources :bookings
+          end
+        end
+
+        class Apps::Clients < Matestack::Ui::App
+          def response
+            components {
+              page_content
+            }
+          end
+        end
+
+        module Pages::Clients::Bookings
+        end
+
+        class Pages::Clients::Bookings::Show < Matestack::Ui::Page
+          def response
+            components {
+              plain "Hello from the Pages::Clients::Bookings::Show page with id #{@id}."
+            }
+          end
+        end
+      end
+      after do
+        Rails.application.reload_routes!
+        Pages::Clients.send :remove_const, :Bookings
+      end
+      specify do
+        visit "/clients/bookings/123"
+        expect(page).to have_text "Hello from the Pages::Clients::Bookings::Show page with id 123."
       end
     end
 
@@ -120,7 +217,7 @@ describe Matestack::Ui::Core::Render do
           end
         end
 
-        module Pages::Clients
+        module Pages::Clients::Bookings
         end
 
         class Pages::Clients::Bookings::Step1 < Matestack::Ui::Page
@@ -133,10 +230,243 @@ describe Matestack::Ui::Core::Render do
       end
       after do
         Rails.application.reload_routes!
+        Pages::Clients.send :remove_const, :Bookings
       end
       specify do
         visit "/clients/bookings/step1"
         expect(page).to have_text "Hello from the Pages::Clients::Bookings::Step1 page."
+      end
+    end
+
+    describe "when page classes end with 'Page'" do # just like BookingsController ends with 'Controller'
+      describe "implicit rendering for index actions", type: :feature, js: true do
+        before do
+          module Clients
+          end
+
+          class Clients::BookingsController < ApplicationController
+            include Matestack::Ui::Core::ApplicationHelper
+
+            def index
+            end
+          end
+
+          Rails.application.routes.draw do
+            namespace :clients do
+              resources :bookings
+            end
+          end
+
+          class Apps::Clients < Matestack::Ui::App
+            def response
+              components {
+                page_content
+              }
+            end
+          end
+
+          class Clients::BookingsPage < Matestack::Ui::Page
+            def response
+              components {
+                plain "Hello from the Clients::BookingsPage."
+              }
+            end
+          end
+        end
+        after do
+          Rails.application.reload_routes!
+          Clients.send :remove_const, :BookingsPage
+        end
+        specify do
+          visit "/clients/bookings"
+          expect(page).to have_text "Hello from the Clients::BookingsPage."
+        end
+      end
+
+      describe "implicit rendering for index actions with explicit index page name", type: :feature, js: true do
+        before do
+          module Clients
+          end
+
+          class Clients::BookingsController < ApplicationController
+            include Matestack::Ui::Core::ApplicationHelper
+
+            def index
+            end
+          end
+
+          Rails.application.routes.draw do
+            namespace :clients do
+              resources :bookings
+            end
+          end
+
+          class Apps::Clients < Matestack::Ui::App
+            def response
+              components {
+                page_content
+              }
+            end
+          end
+
+          module Clients::Bookings
+          end
+
+          class Clients::Bookings::IndexPage < Matestack::Ui::Page
+            def response
+              components {
+                plain "Hello from the Clients::Bookings::IndexPage."
+              }
+            end
+          end
+        end
+        after do
+          Rails.application.reload_routes!
+          Clients::Bookings.send :remove_const, :IndexPage
+        end
+        specify do
+          visit "/clients/bookings"
+          expect(page).to have_text "Hello from the Clients::Bookings::IndexPage."
+        end
+      end
+
+      describe "implicit rendering for show actions", type: :feature, js: true do
+        before do
+          module Clients
+          end
+
+          class Clients::BookingsController < ApplicationController
+            include Matestack::Ui::Core::ApplicationHelper
+
+            def show
+              @id = params[:id]
+            end
+          end
+
+          Rails.application.routes.draw do
+            namespace :clients do
+              resources :bookings
+            end
+          end
+
+          class Apps::Clients < Matestack::Ui::App
+            def response
+              components {
+                page_content
+              }
+            end
+          end
+
+          class Clients::BookingPage < Matestack::Ui::Page
+            def response
+              components {
+                plain "Hello from the Clients::BookingPage with id #{@id}."
+              }
+            end
+          end
+        end
+        after do
+          Rails.application.reload_routes!
+        end
+        specify do
+          visit "/clients/bookings/123"
+          expect(page).to have_text "Hello from the Clients::BookingPage with id 123."
+        end
+      end
+
+      describe "implicit rendering for show actions with explicit show page name", type: :feature, js: true do
+        before do
+          module Clients
+          end
+
+          class Clients::BookingsController < ApplicationController
+            include Matestack::Ui::Core::ApplicationHelper
+
+            def show
+              @id = params[:id]
+            end
+          end
+
+          Rails.application.routes.draw do
+            namespace :clients do
+              resources :bookings
+            end
+          end
+
+          class Apps::Clients < Matestack::Ui::App
+            def response
+              components {
+                page_content
+              }
+            end
+          end
+
+          module Clients::Bookings
+          end
+
+          class Clients::Bookings::ShowPage < Matestack::Ui::Page
+            def response
+              components {
+                plain "Hello from the Clients::Bookings::ShowPage with id #{@id}."
+              }
+            end
+          end
+        end
+        after do
+          Rails.application.reload_routes!
+          Clients::Bookings.send :remove_const, :ShowPage
+        end
+        specify do
+          visit "/clients/bookings/123"
+          expect(page).to have_text "Hello from the Clients::Bookings::ShowPage with id 123."
+        end
+      end
+
+      describe "implicit rendering for custom actions", type: :feature, js: true do
+        before do
+          module Clients
+          end
+
+          class Clients::BookingsController < ApplicationController
+            include Matestack::Ui::Core::ApplicationHelper
+
+            def step1
+            end
+          end
+
+          Rails.application.routes.draw do
+            namespace :clients do
+              get 'bookings/step1', to: 'bookings#step1'
+            end
+          end
+
+          class Apps::Clients < Matestack::Ui::App
+            def response
+              components {
+                page_content
+              }
+            end
+          end
+
+          module Clients::Bookings
+          end
+
+          class Clients::Bookings::Step1Page < Matestack::Ui::Page
+            def response
+              components {
+                plain "Hello from the Clients::Bookings::Step1Page."
+              }
+            end
+          end
+        end
+        after do
+          Rails.application.reload_routes!
+          Clients::Bookings.send :remove_const, :Step1Page
+        end
+        specify do
+          visit "/clients/bookings/step1"
+          expect(page).to have_text "Hello from the Clients::Bookings::Step1Page."
+        end
       end
     end
 

--- a/spec/matestack/ui/core/renderer_spec.rb
+++ b/spec/matestack/ui/core/renderer_spec.rb
@@ -1,0 +1,98 @@
+describe Matestack::Ui::Core::Render do
+  describe "#default_render" do
+
+    describe "implicit rendering for index actions", type: :feature, js: true do
+      before do
+        module Clients
+        end
+
+        class Clients::BookingsController < ApplicationController
+          include Matestack::Ui::Core::ApplicationHelper
+
+          def index
+          end
+        end
+
+        Rails.application.routes.draw do
+          namespace :clients do
+            resources :bookings
+          end
+        end
+
+        class Apps::Clients < Matestack::Ui::App
+          def response
+            components {
+              page_content
+            }
+          end
+        end
+
+        module Pages::Clients
+        end
+
+        class Pages::Clients::Bookings < Matestack::Ui::Page
+          def response
+            components {
+              plain "Hello from the Pages::Clients::Bookings page."
+            }
+          end
+        end
+      end
+      after do
+        Rails.application.reload_routes!
+      end
+      specify do
+        visit "/clients/bookings"
+        expect(page).to have_text "Hello from the Pages::Clients::Bookings page."
+      end
+    end
+
+    describe "implicit rendering for show actions", type: :feature, js: true do
+      before do
+        module Clients
+        end
+
+        class Clients::BookingsController < ApplicationController
+          include Matestack::Ui::Core::ApplicationHelper
+
+          def show
+            @id = params[:id]
+          end
+        end
+
+        Rails.application.routes.draw do
+          namespace :clients do
+            resources :bookings
+          end
+        end
+
+        class Apps::Clients < Matestack::Ui::App
+          def response
+            components {
+              page_content
+            }
+          end
+        end
+
+        module Pages::Clients
+        end
+
+        class Pages::Clients::Booking < Matestack::Ui::Page  # singular name `Booking`!
+          def response
+            components {
+              plain "Hello from the Pages::Clients::Booking page with id #{@id}."
+            }
+          end
+        end
+      end
+      after do
+        Rails.application.reload_routes!
+      end
+      specify do
+        visit "/clients/bookings/123"
+        expect(page).to have_text "Hello from the Pages::Clients::Booking page with id 123."
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/302: action-view interoperability

### Changes

- The view context is exposed to matestack components and pages. (https://github.com/basemate/matestack-ui-core/pull/302/commits/b322a6945bb31500dfcb524df886c4668a2c6c6c)
- The `render` method, commonly used in rails, is extended to support matestack pages. (https://github.com/basemate/matestack-ui-core/pull/302/commits/42d24fa83588c6310f60a4450297ac1c0b68963b)
- Implicit rendering, commonly used in rails controllers, is extended to support matestack pages. (https://github.com/basemate/matestack-ui-core/pull/302/commits/fc78b66d00e88a26df750cc8b064f5a1482353ba)
- Helper methods like `link_to`, which return an `ActiveSupport::SafeBuffer`, are implicitly wrapped in a `plain` component when used in matestack components or pages. (https://github.com/basemate/matestack-ui-core/pull/302/commits/ba93b3249643163861d51be295285c186d7ef989)

### Notes

The changes proposed in this pull request intend to make matestack easier to use by newcomers.

#### Exposing the view context

When rendering matestack pages or controllers from a controller, which includes the `Matestack::Ui::Core::ApplicationHelper`, the controller's `view_context` is passed as context to the matestack object, which exposes the view context to its components. This way, helpers and other methods exposed by the controller to the vanilla-rails views, can also be used from matestack pages or components.

For example, the `current_user` method from [devise](https://github.com/plataformatec/devise), the `can?` method from [cancancan](https://github.com/CanCanCommunity/cancancan), or methods exposed by [decent_exposure](https://github.com/hashrocket/decent_exposure) (`bookings` in the example below) can be used in matestack objects.

```ruby
class BookingsController < ApplicationController
  include Matestack::Ui::Core::ApplicationHelper
  before_action :authenticate_user!
  helper_method :current_user
  expose :bookings, -> { current_user.bookings }

  def index
    responder_for Pages::Bookings
  end
end

class Pages::Bookings < Matestack::Ui::Page
  def response
    components {
      heading size: 1, text: "#{current_user.name}'s bookings"
      ul do
        bookings.each do |booking|
          li { plain booking.name }
        end
      end
      if can? :create, Booking
        link text: "Add booking"
      end
    }
  end
end
``` 

#### Explicit rendering of matestack pages

The [`render` method](https://apidock.com/rails/ActionController/Base/render) of rails is extended to also support matestack pages. This way, the `render` method can be used instead of `responder_for` in controllers.

```ruby
class Admins::BookingsController < ApplicationController
  include Matestack::Ui::Core::ApplicationHelper
  
  def index
    # The following calls are equivalent:
    render matestack: 'admins/bookings'
    render matestack: Pages::Admins::Bookings
    render Pages::Admins::Bookings
    respnder_for Pages::Admins::Bookings
  end
end
```

#### Implicit rendering of matestack pages

In rails, when a controller action has no explicit `render` call, the view to render is inferred from the controller name and the controller action. This pull request extends this mechanism to support matestack pages.

```ruby
class Admins::BookingsController < ApplicationController
  include Matestack::Ui::Core::ApplicationHelper
  
  def index
  end
  
  def show
  end
end

class Pages::Admins::Bookings < Matestack::Ui::Page
  def response
    components {
      plain "Hello from admins/bookings#index"
    }
  end
end

class Pages::Admins::Booking < Matestack::Ui::Page
  def response
    components {
      plain "Hello from admins/bookings#show"
    }
  end
end
```

The `index` action looks for a matestack page matching the controller namespace (`Admins`) and the controller name in plural (`Bookings`). The `show` action looks for a matestack page matching the controller namespace and the controller name in singular (`Booking`).

#### Implicitly rendering legacy helpers in plain components

Using vanilla-rails helpers like `link_to` in matestack components or pages, does not raise an error, but does not render the helpers' output. For example:

```ruby
class Components::Layout::SignInSignOutButton < Matestack::Ui::StaticComponent
  def response
    components {
      if not current_user
        link_to "Sign in", new_user_session_path
      else
        plain "Welcome, #{current_user.name}!"
        link_to "Sign out", destroy_user_session_path, method: :delete
      end
    }
  end
end
```

One could render these vanilla-rails helpers by prefixing them with a `plain` component (`plain link_to "Sign in"`).

This pull request prefixes `link_to` and other helpers returning an `ActiveSupport::SafeBuffer` implicitly with `plain`, making the above example work.

```ruby
def response
  components {
    heading size: 1, text: "The following calls are equivalent:"
    plain link_to "Sign in", new_user_session_path
    link_to "Sign in", new_user_session_path
  }
end
```