### PR TITLE
Change spelling of behaviour to behavior

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,18 +1,18 @@
-<!-- This is a template only, remove/add sections below as appropriate (e.g. for a new feature, there might be no 'current behaviour'.) -->
+<!-- This is a template only, remove/add sections below as appropriate (e.g. for a new feature, there might be no 'current behavior'.) -->
 
 <!-- First indicate whether you want to request an ENHANCEMENT or report a BUG by using the correct Github label in the side panel* -->
 
-**What is the current behaviour?**
+**What is the current behavior?**
 
-<!-- add current behaviour here -->
+<!-- add current behavior here -->
 
-**If the current behaviour is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem. Your bug might get fixed faster if we can run your code and it doesn't have extra dependencies. Add a link to a sample repo and/or any relevant code below:**
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem. Your bug might get fixed faster if we can run your code and it doesn't have extra dependencies. Add a link to a sample repo and/or any relevant code below:**
 
 <!-- add additional links/info here -->
 
-**What is the expected behaviour?**
+**What is the expected behavior?**
 
-<!-- add expected behaviour here -->
+<!-- add expected behavior here -->
 
 **Which versions of Matestack, and which browser/OS are affected by this issue? Did this work in previous versions of Matestack?**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ none
 
 ### Bugfixes
 
-* Unexpected behaviour when creating a record in progress by jonasjabari
+* Unexpected behavior when creating a record in progress by jonasjabari
 * couldn't find file 'matestack_ui_core_manifest.js' on dummy app by jonasjabari
 * Add For Attribute to Stand Alone Label Component by bdlb77
 * Form component doesn't work on component-level by jonasjabari

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -399,7 +399,7 @@ The Cells get wrapped by a `component` tag. `dynamic_tag_attributes` returns a h
 - `"ref": component_id` may be used to identify the specific instance of this Component on one Page
 - `:params":  @url_params.to_json` is used to pass request params to the Vue.js Component instance
 - `":component-config": @component_config.to_json` is used to pass configuration to the Vue.js Component instance
-  - this is very useful if a Vue.js component relies on meta data to perfom its desired behaviour during runtime
+  - this is very useful if a Vue.js component relies on meta data to perfom its desired behavior during runtime
   - example: the dynamic core Component `transition` gets a `path` config when used in a `response` method. As the value is just a symbol referencing a rails route, the Component needs to translate the symbol to a string on the server-side. This string is then added to the `@component_config` and parsed by the `transition` Vue.js component instance during browser runtime
 - `"inline-template": true` needs to be set in order to tell Vue.js that this component uses the server-side rendered markup as template.
 

--- a/docs/concepts/component.md
+++ b/docs/concepts/component.md
@@ -8,7 +8,7 @@ This document aims to give a brief introducing to the different kinds of compone
 
 ## Core Components
 
-See [here](/docs/components/README.md) for a list of available `core components`. In general, they are separated into HTML-only **static** components and **dynamic** components that come with Javascript-powered, dynamic behaviour.
+See [here](/docs/components/README.md) for a list of available `core components`. In general, they are separated into HTML-only **static** components and **dynamic** components that come with Javascript-powered, dynamic behavior.
 
 If you miss a component that you think we're missing in the `core components` right now, [create an issue](https://github.com/basemate/matestack-ui-core/issues/new) in our GitHub!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,11 +41,11 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
+  # RSpec Rails can automatically mix in different behaviors to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
   #
-  # You can disable this behaviour by removing the line below, and instead
+  # You can disable this behavior by removing the line below, and instead
   # explicitly tag your specs with their type, e.g.:
   #
   #     RSpec.describe UsersController, :type => :controller do

--- a/spec/usage/base/component_spec.rb
+++ b/spec/usage/base/component_spec.rb
@@ -297,9 +297,9 @@ describe "Component", type: :feature, js: true do
 
     end
 
-    it "components can use async component to wrap static components and add basic dynamic behaviour" #not working right now
+    it "components can use async component to wrap static components and add basic dynamic behavior" #not working right now
 
-    it "pages can use async component to wrap static components and add basic dynamic behaviour" do
+    it "pages can use async component to wrap static components and add basic dynamic behavior" do
 
       module Matestack::Ui::Core::SomeStaticComponent
         class SomeStaticComponent < Matestack::Ui::StaticComponent


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/310: Fix spelling errors in website/docs

### Changes

- [x] Search & replace of `behaviour` => `behavior`

### Notes
Other spelling errors will be fixed in the `docs`-repo