### PR TITLE
Upgrade bundler to the 2.x line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
           - v1-dependencies-
 
       - run:
+          name: Get newest bundler
+          command: gem install bundler
+
+      - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,4 +274,4 @@ DEPENDENCIES
   webpacker (~> 3.5)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
1.17.3 is older than a year, bundler 2 is safe to use after it's initial issues :)

(without this people, like me, who only had bundler 2 installed would have to install the old bundler)

also fixes the broken self reference version.