### PR TITLE
Fix Note for running tests on Mac

### DIFF
--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -55,7 +55,7 @@ bundle exec rspec
 
 Tests follow quite the same rules as the documentation: Make sure to either add relevant tests (when introducing new concepts or components) or change existing ones to fit your changes (updating existing concepts and components). Pull requests that add/change concepts & components and do not come with corresponding tests will not be approved.
 
-### Note: Running tests on macOS
+### Note: Running tests on macOS
 
 Make sure you have installed `chromedriver` on your machine. You can install `chromedriver` via `brew` with
 


### PR DESCRIPTION
No idea why before it didn't work, basically rewrote it and now the parser realizes its mistake - maybe an odd character/whitespace?

![image](https://user-images.githubusercontent.com/606517/73171695-aeb39980-4101-11ea-9ddd-89582fbcfb54.png)