### PR TITLE
HasViewContext: Check in advance whether the view context would responnd to a missing method.

### DIFF
--- a/app/lib/matestack/ui/core/has_view_context.rb
+++ b/app/lib/matestack/ui/core/has_view_context.rb
@@ -5,6 +5,10 @@ module Matestack::Ui::Core::HasViewContext
   end
 
   def method_missing(*args, &block)
-    @view_context.send(*args, &block)
+    if @view_context.respond_to? args.first
+      @view_context.send(*args, &block)
+    else
+      super
+    end
   end
 end


### PR DESCRIPTION
I just came across this while debugging.

### Changes

- Before delegating a missing method to the view context, check whether the view context actually has this method.

### Notes

- I've introduced `HasViewContext` in https://github.com/matestack/matestack-ui-core/pull/302.
- This change makes it easier to track down the issue if a method is actually missing also in the view context.