### PR TITLE
Adding support for i18n lazy lookups to matestack pages

### DIFF
--- a/app/concepts/matestack/ui/core/page/page.rb
+++ b/app/concepts/matestack/ui/core/page/page.rb
@@ -6,6 +6,7 @@ module Matestack::Ui::Core::Page
     include Matestack::Ui::Core::ApplicationHelper
     include Matestack::Ui::Core::ToCell
     include Matestack::Ui::Core::HasViewContext
+    include Matestack::Ui::Core::HasScopedI18n
 
     view_paths << "#{Matestack::Ui::Core::Engine.root}/app/concepts"
 

--- a/app/lib/matestack/ui/core/has_scoped_i18n.rb
+++ b/app/lib/matestack/ui/core/has_scoped_i18n.rb
@@ -1,0 +1,42 @@
+module Matestack::Ui::Core::HasScopedI18n
+
+  # ## Adding scoped translations to matestack ("lazy lookup").
+  #
+  # This is a namespacing mechanism for translations.
+  #
+  # Consider this locale:
+  #
+  #     # config/locales/sessions/en.yml
+  #     en:
+  #       sessions:
+  #         new:
+  #           sign_in: Sign in
+  #           email: Email
+  #           password: Password
+  #
+  # These translations usually can be accessed via their full key:
+  #
+  #     translate 'sessions.new.sign_in'  # => "Sign in"
+  #
+  # Inside pages rendered from the `sessions#new` controller action,
+  # these translations can be accessed via the following short form:
+  #
+  #     translate '.sign_in'  # => "Sign in"
+  #
+  # This mirrors the convention provided by rails for views and controllers:
+  # https://guides.rubyonrails.org/i18n.html#lazy-lookup
+  #
+  def translate(*args)
+    key = args.first
+    if key.is_a?(String) && (key[0] == '.')
+      key = "#{ controller_path.gsub('/', '.') }.#{ action_name }#{ key }"
+      args[0] = key
+    end
+    super(*args)
+  end
+
+  def t(*args)
+    translate(*args)
+  end
+
+end


### PR DESCRIPTION
### Changes

- The shorthand syntax `translate '.sign_in'` (String with leading dot) can be used in matestack pages to access scoped translations.

### Notes

- This mirrors the behaviour used in rails views and rails controllers, https://guides.rubyonrails.org/i18n.html#lazy-lookup.

## Adding scoped translations to matestack ("lazy lookup")

This is a namespacing mechanism for translations.

Consider this locale:

```yaml
# config/locales/sessions/en.yml
en:
  sessions:
    new:
      sign_in: Sign in
      email: Email
      password: Password
```


These scoped translations usually can be accessed via their full key:

    translate 'sessions.new.sign_in'  # => "Sign in"

**New**: Inside pages rendered from the `sessions#new` controller action,
these translations can be accessed via the following short form:

    translate '.sign_in'  # => "Sign in"

This mirrors the convention provided by rails for views and controllers:
https://guides.rubyonrails.org/i18n.html#lazy-lookup