### PR TITLE
Add datalist component, update input and form_input to handle type range

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ group :development, :test do
   gem 'puma'
   gem 'simplecov', require: false, group: :test
   gem 'byebug'
-  gem 'pry-byebug'
   gem 'webmock'
   gem 'pry-rails'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    matestack-ui-core (0.7.3)
+    matestack-ui-core (0.7.4)
       cells-haml
       cells-rails
       haml

--- a/app/concepts/matestack/ui/core/datalist/datalist.haml
+++ b/app/concepts/matestack/ui/core/datalist/datalist.haml
@@ -1,0 +1,3 @@
+%datalist{@tag_attributes}
+  - if block_given?
+    = yield

--- a/app/concepts/matestack/ui/core/datalist/datalist.rb
+++ b/app/concepts/matestack/ui/core/datalist/datalist.rb
@@ -1,0 +1,5 @@
+module Matestack::Ui::Core::Datalist
+  class Datalist < Matestack::Ui::Core::Component::Static
+
+  end
+end

--- a/app/concepts/matestack/ui/core/form/input/input.haml
+++ b/app/concepts/matestack/ui/core/form/input/input.haml
@@ -1,27 +1,38 @@
-- if options[:label]
-  %label=options[:label]
+- if label
+  %label=label
 
-- if [:text, :number, :email, :date, :password].include?(options[:type])
-  %input{@tag_attributes,
-    "v-model#{'.number' if options[:type] == :number}": input_key,
-    type: options[:type],
+- if [:text, :number, :email, :date, :password].include?(type)
+  %input{ @tag_attributes,
+    "v-model#{'.number' if type == :number}": input_key,
+    type: type,
     "@change": "inputChanged(\"#{attr_key}\")",
     ref: "input.#{attr_key}",
-    placeholder: options[:placeholder],
-    "init-value": init_value}
-  %span{class: "errors", "v-if": error_key }
-    %span{class: "error", "v-for": "error in  #{error_key}"}
-      {{ error }}
+    placeholder: placeholder,
+    "init-value": init_value }
 
-- if options[:type] == :textarea
-  %textarea{@tag_attributes,
+- if type == :textarea
+  %textarea{ @tag_attributes,
     "v-model": input_key,
     "@change": "inputChanged(\"#{attr_key}\")",
     ref: "input.#{attr_key}",
-    placeholder: options[:placeholder],
+    placeholder: placeholder,
     "init-value": init_value,
     rows: options[:rows],
-    cols: options[:cols]}
-  %span{class: "errors", "v-if": error_key }
-    %span{class: "error", "v-for": "error in  #{error_key}"}
-      {{ error }}
+    cols: options[:cols] }
+
+- if type == :range
+  %input{ @tag_attributes,
+    "v-model": input_key,
+    type: :range,
+    "@change": "inputChanged(\"#{attr_key}\")",
+    ref: "input.#{attr_key}",
+    placeholder: placeholder,
+    "init-value": init_value,
+    min: options[:min],
+    max: options[:max],
+    step: options[:step],
+    list: options[:list] }
+
+%span{ class: "errors", "v-if": error_key }
+  %span{ class: "error", "v-for": "error in #{error_key}" }
+    {{ error }}

--- a/app/concepts/matestack/ui/core/input/input.haml
+++ b/app/concepts/matestack/ui/core/input/input.haml
@@ -1,3 +1,2 @@
-%input{@tag_attributes}
-  - if block_given?
-    = yield
+%input{ @tag_attributes,
+  type: type }

--- a/app/concepts/matestack/ui/core/input/input.rb
+++ b/app/concepts/matestack/ui/core/input/input.rb
@@ -1,5 +1,9 @@
 module Matestack::Ui::Core::Input
   class Input < Matestack::Ui::Core::Component::Static
 
+    def type
+      options[:type]
+    end
+
   end
 end

--- a/docs/components/datalist.md
+++ b/docs/components/datalist.md
@@ -1,0 +1,31 @@
+# matestack core component: Datalist
+
+Show [specs](/spec/usage/components/datalist_spec.rb)
+
+The HTML `<datalist>` tag implemented in Ruby.
+
+## Parameters
+
+This component can take 2 optional configuration params and yield content.
+
+#### # id (optional)
+Expects a string with all ids the datalist should have.
+
+#### # class (optional)
+Expects a string with all classes the datalist should have.
+
+
+## Example 1
+Adding an optional id
+
+```ruby
+datalist id: 'foo', class: 'bar' do
+  plain 'Example Text'
+end
+```
+
+returns
+
+```html
+<datalist id="foo" class="bar">Example Text</datalist>
+```

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -578,7 +578,7 @@ end
 
 ### Example 4: Multiple input fields of different types
 
-Of course, our input core component accepts not only 'text', but very different input types: In this example, we will introduce 'password', 'number', 'email', 'textarea' types!
+Of course, our input core component accepts not only 'text', but very different input types: In this example, we will introduce 'password', 'number', 'email', 'range', 'textarea' types!
 
 On our example page, we define the input fields, together with a `type: X` configuration:
 
@@ -592,6 +592,7 @@ class ExamplePage < Matestack::Ui::Page
         form_input id: 'email-input',     key: :email_input, type: :email
         form_input id: 'password-input',  key: :password_input, type: :password
         form_input id: 'number-input',    key: :number_input, type: :number
+        form_input id: 'range-input',     key: :range_input, type: :range
         form_input id: 'textarea-input',  key: :textarea_input, type: :textarea
         form_submit do
           button text: 'Submit me!'
@@ -1326,3 +1327,25 @@ end
 ```
 
 Again, we can visit our example page on `localhost:3000/example` and are welcome by the preselected status of our `TestModel` instance. Changing the value of the status by toggling the radio button and filling in a description plus submitting it works just as before!
+
+#### Example 10.4: The Range Input
+
+Whilst working similiar to the 'text' input, the range input accepts a few more parameters. It accepts also 'min', 'max', 'step', 'list' as optional parameters.
+
+##### Example 10.4.1: Range input with max, min, step set
+
+```ruby
+form_input id: 'range-input', type: :range, min: 0, max: 100, step: 1
+```
+
+#### Example 10.4.2: Range input with corresponding datalist
+
+To use a datalist for the range input specify the 'list' parameter with the id of the provided datalist
+
+```ruby
+form_input id: 'range-input', type: :range, list: 'datalist-id'
+datalist id: 'datalist-id' do
+  option value: 10
+  option value: 20
+end
+```

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -1,0 +1,30 @@
+# matestack core component: Input
+
+Show [specs](/spec/usage/components/input_spec.rb)
+
+The HTML input tag implemented in ruby.
+
+## Parameters
+
+This component can take 3 optional configuration params and optional content.
+
+#### # id (optional)
+Expects a string with all ids the main should have.
+
+#### # class (optional)
+Expects a string with all classes the main should have.
+
+#### # type (optional)
+Expects a symbol with that specifies the input type.
+
+## Example
+
+```ruby
+input type: :text, id: "foo", class: "bar"
+```
+
+returns
+
+```html
+<input type="text" id="foo" class="bar" />
+```

--- a/spec/usage/components/datalist_spec.rb
+++ b/spec/usage/components/datalist_spec.rb
@@ -1,0 +1,31 @@
+require_relative "../../support/utils"
+include Utils
+
+describe 'Datalist Component', type: :feature, js: true do
+
+  it 'Example 1 - yield' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          datalist id: 'foo', class: 'bar' do
+            plain 'Example Text'
+          end
+        }
+      end
+
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <datalist id="foo" class="bar">Example Text</datalist>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+end

--- a/spec/usage/components/form_spec.rb
+++ b/spec/usage/components/form_spec.rb
@@ -702,7 +702,7 @@ describe "Form Component", type: :feature, js: true do
 
   describe "Form Input Component" do
 
-    it "Example 1 - Supports 'text', 'password', 'number', 'email', 'textarea' type" do
+    it "Example 1 - Supports 'text', 'password', 'number', 'email', 'textarea', 'range' type" do
 
       class ExamplePage < Matestack::Ui::Page
 
@@ -714,6 +714,7 @@ describe "Form Component", type: :feature, js: true do
               form_input id: "password-input",  key: :password_input, type: :password
               form_input id: "number-input",    key: :number_input, type: :number
               form_input id: "textarea-input",  key: :textarea_input, type: :textarea
+              form_input id: "range-input",     key: :range_input, type: :range
               form_submit do
                 button text: "Submit me!"
               end
@@ -741,7 +742,7 @@ describe "Form Component", type: :feature, js: true do
       fill_in "password-input", with: "secret"
       fill_in "number-input", with: 123
       fill_in "textarea-input", with: "Hello \n World!"
-      
+      fill_in "range-input", with: 10
 
       expect_any_instance_of(FormTestController).to receive(:expect_params)
         .with(hash_including(
@@ -750,7 +751,8 @@ describe "Form Component", type: :feature, js: true do
             email_input: "name@example.com",
             password_input: "secret",
             number_input: 123,
-            textarea_input: "Hello \n World!"
+            textarea_input: "Hello \n World!",
+            range_input: "10"
           }
         ))
 
@@ -1322,7 +1324,7 @@ describe "Form Component", type: :feature, js: true do
 
         expect_any_instance_of(FormTestController).to receive(:expect_params)
           .with(hash_including(my_object: { array_input: ["Array Option 1", "Array Option 2"], hash_input: ["2"] }))
-          
+
         click_button "Submit me!"
 
       end
@@ -1831,6 +1833,43 @@ describe "Form Component", type: :feature, js: true do
         click_button "Submit me!"
       end
     end
+
+  end
+
+  it "range input can be initialized with min, max, step and value" do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          form form_config, :include do
+            form_input id: "range-input",
+              key: :range_input, type: :range,
+              init: 3, min: 0, max: 10, step: 1, list: "my_list"
+            form_submit do
+              button text: "Submit me!"
+            end
+          end
+        }
+      end
+
+      def form_config
+        return {
+          for: :my_object,
+          method: :post,
+          path: :success_form_test_path,
+          params: {
+            id: 42
+          }
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    expect(page).to have_field("range-input", with: "3")
+    expect(page).to have_selector('#range-input[min="0"][max="10"][step="1"][list="my_list"]')
 
   end
 

--- a/spec/usage/components/input_spec.rb
+++ b/spec/usage/components/input_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Input Component', type: :feature, js: true do
+
+  it 'Example 1' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          # simple input tag
+          input
+
+          # email input tag
+          input type: :email
+
+          # range input with max, min, step
+          input type: :range, attributes: { min: 0, max: 10, step: 0.5 }
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <input />
+    <input type="email" />
+    <input max="10" min="0" step="0.5" type="range" />
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+end


### PR DESCRIPTION
## Issue https://github.com/matestack/matestack-ui-core/issues/82: Add a range input to matestacks core components

### Changes

- [x] Updated input component to accept type parameter
- [x] Updated form_input component to handle input type range
- [x] Added datalist core component
- [x] Update/expand documentation for datalist, input, form_input
- [x] update/expand tests for datalist, input, form_input

### Notes

- Code cleanup in form_input component
