### PR TITLE
Add params method to base component

### DIFF
--- a/app/concepts/matestack/ui/core/component/base.rb
+++ b/app/concepts/matestack/ui/core/component/base.rb
@@ -5,7 +5,7 @@ module Matestack::Ui::Core::Component
     include Matestack::Ui::Core::HtmlAttributes
     include Matestack::Ui::Core::Properties
 
-    # define html global attributes 
+    # define html global attributes
     html_attributes *HTML_GLOBAL_ATTRIBUTES, *HTML_EVENT_ATTRIBUTES
 
     # probably eed to remove for other tests to be green again
@@ -67,6 +67,7 @@ module Matestack::Ui::Core::Component
 
       # TODO: no idea why this is called `url_params` it contains
       # much more than this e.g. almost all params so maybe rename it?
+      # will be deprecated in future releases. use the `params` method in order to access query params
       @url_params = context&.[](:params)&.except(:action, :controller, :component_key, :matestack_context)
 
       # used when creating the child component tree
@@ -157,6 +158,11 @@ module Matestack::Ui::Core::Component
     # Seems like it might be more complicated? Not sure probably missing something.
     def prepare
       true
+    end
+
+    # access params like you would do on rails views and controllers
+    def params
+      context[:params]
     end
 
     ## ------------------ Rendering ----------------
@@ -318,7 +324,7 @@ module Matestack::Ui::Core::Component
       case args.size
       when 0 then [
         {
-          context: context, 
+          context: context,
           included_config: included_config,
         }
         ]

--- a/app/concepts/matestack/ui/core/component/dynamic.rb
+++ b/app/concepts/matestack/ui/core/component/dynamic.rb
@@ -15,7 +15,7 @@ module Matestack::Ui::Core::Component
       attrs = {
         "is": self.class.vue_js_name,
         "ref": component_id,
-        ":params":  @url_params.to_json,
+        ":params":  params.except(:controller, :action).to_json,
         ":component-config": @component_config.to_json,
         "inline-template": true,
       }
@@ -32,6 +32,6 @@ module Matestack::Ui::Core::Component
         @vue_js_name ||= self.name.split(/(?=[A-Z])/).join("-").downcase.gsub("::", "")
       end
     end
-    
+
   end
 end

--- a/spec/0.8/base/core/component/url_params_access_spec.rb
+++ b/spec/0.8/base/core/component/url_params_access_spec.rb
@@ -35,7 +35,7 @@ describe "Component", type: :feature, js: true do
             div id: "my-component" do
               # TODO: rather than accessing plain instance variables
               # I'd recommend a method based interface (easier to adjust, test, maintain if state is moved elsewhere etc.)
-              plain @url_params[:foo]
+              plain params[:foo]
             end
         end
 

--- a/spec/0.8/base/core/page/url_params_access_spec.rb
+++ b/spec/0.8/base/core/page/url_params_access_spec.rb
@@ -29,7 +29,7 @@ describe "Page", type: :feature, js: true do
 
       def response
         div do
-          plain "Request Params: #{@url_params}"
+          plain "foo: #{params[:foo]}"
         end
       end
 
@@ -37,7 +37,7 @@ describe "Page", type: :feature, js: true do
 
     visit "page_url_params_access_spec/page_test/?foo=bar"
 
-    expect(page).to have_content('Request Params: {"foo"=>"bar"}')
+    expect(page).to have_content("foo: bar")
 
   end
 


### PR DESCRIPTION
### Changes

- [x] added params method to base component in order to access query params as we're used to from rails views and controllers
- [x] adjusted specs
- [x] adjusted `@url_params` usage in `VueJsComponent`
