### PR TITLE
Rename `Vuejs` and `vue` references in doc/ to Vue.js

### DIFF
--- a/docs/api/000-base/00-app.md
+++ b/docs/api/000-base/00-app.md
@@ -7,8 +7,8 @@ An app is a special kind of `Matestack::Ui::VueJsComponent`. Matestack will
 therefore wrap the UI defined in the `response` method with some markup enabling
 dynamic UI behavior and CSS styling.
 
-The app ships a `Vuex store` and `Vue.js event hub`, which are used by core vuejs
-components and can optionally be used by custom vuejs components in order to
+The app ships a `Vuex store` and `Vue.js event hub`, which are used by core Vue.js
+components and can optionally be used by custom Vue.js components in order to
 trigger events, manage client side date and communicate between components.
 
 ## An App can wrap pages with a layout

--- a/docs/api/000-base/30-vue_js_component.md
+++ b/docs/api/000-base/30-vue_js_component.md
@@ -1,18 +1,18 @@
-# VueJs Component
+# Vue.js Component
 
 In order to equip a Ruby component with some JavaScript, we associate
-the Ruby component with a VueJs JavaScript component. The Ruby component therefore needs to inherit
+the Ruby component with a Vue.js JavaScript component. The Ruby component therefore needs to inherit
 from `Matestack::Ui::VueJsComponent`. Matestack will then render a HTML component
 tag with some special attributes and props around the response defined in the
-Ruby component. The VueJs JavaScript component (defined in a separate JavaScript file and
+Ruby component. The Vue.js JavaScript component (defined in a separate JavaScript file and
 managed via Sprockets or Webpacker) will treat the response of the Ruby
 component as its template.
 
 ## Structure, files and registry
 
-A VueJs component is defined by two files. A Ruby file and a JavaScript file:
+A Vue.js component is defined by two files. A Ruby file and a JavaScript file:
 
-### VueJs Ruby component
+### Vue.js Ruby component
 
 Within the Ruby file, the Ruby class inherits from `Matestack::Ui::VueJsComponent`:
 
@@ -48,9 +48,9 @@ module Components::Registry
   )
 end
 ```
-### VueJs JavaScript component
+### Vue.js JavaScript component
 
-The VueJs JavaScript component is defined in a separate JavaScript file:
+The Vue.js JavaScript component is defined in a separate JavaScript file:
 
 `app/matestack/components/some_component.js`
 
@@ -73,7 +73,7 @@ it right next to the Ruby component file.
 
 *Important*
 
-The VueJs JavaScript file needs to be imported by some kind of JavaScript package
+The Vue.js JavaScript file needs to be imported by some kind of JavaScript package
 manager. This could be `Sprockets` or `Webpacker`
 
 For **Sprockets** it would be something like:
@@ -112,29 +112,29 @@ If setup correctly, matestack will render the component to:
 </component>
 ```
 
-As you can see, the component tag is referencing the VueJs JavaScript component via `is`
+As you can see, the component tag is referencing the Vue.js JavaScript component via `is`
 and tells the JavaScript component that it should use the inner html (coming from the `response` method)
 as the `inline-template` of the component.
 
 `{{ foo }}` will be evaluated to "bar" as soon as Vue.js has booted and mounted
 the component in the browser.
 
-Matestack will inject JSON objects into the VueJs JavaScript component through
+Matestack will inject JSON objects into the Vue.js JavaScript component through
 the `component-config` and `params` props if either component config or params are
 available. This data is injected once on initial serverside rendering of the component's
-markup. See below, how you can pass in data to the VueJs JavaScript component.
+markup. See below, how you can pass in data to the Vue.js JavaScript component.
 
-## VueJs Ruby component API
+## Vue.js Ruby component API
 
 ### Same as component
 
-The basic VueJs Ruby component API is the same as described within the
+The basic Vue.js Ruby component API is the same as described within the
 [component API documenation](/docs/api/000-base/20-component.md). The options below extend
 this API.
 
-### Referencing the VueJs JavaScript component
+### Referencing the Vue.js JavaScript component
 
-As seen above, the VueJs JavaScript component name has to be referenced in the VueJs
+As seen above, the Vue.js JavaScript component name has to be referenced in the Vue.js
 Ruby component using the `vue_js_component_name` class method
 
 `app/matestack/components/some_component.rb`
@@ -148,7 +148,7 @@ class SomeComponent < Matestack::Ui::VueJsComponent
 end
 ```
 
-### Passing data to the VueJs JavaScript component
+### Passing data to the Vue.js JavaScript component
 
 Like seen above, matestack renders a `component-config` prop as an attribute of
 the component tag. In order to fill in some date there, you should use the `setup`
@@ -174,9 +174,9 @@ This data is then available as:
 this.componentConfig["some_serverside_data"]
 ```
 
-within the VueJs JavaScript component.
+within the Vue.js JavaScript component.
 
-## VueJs JavaScript component API
+## Vue.js JavaScript component API
 
 ### Component mixin
 
@@ -279,6 +279,6 @@ As we're pretty much implementing pure Vue.js components, you can refer to the
 [Vue.js guides](https://vuejs.org/v2/guide/) in order to learn more about Vue.js component
 usage
 
-## VueJs JavaScript component scope
+## Vue.js JavaScript component scope
 
 TODO

--- a/docs/api/000-base/40-isolated_component.md
+++ b/docs/api/000-base/40-isolated_component.md
@@ -155,7 +155,7 @@ With `init_on` you can specify events on which the isolate components gets initi
 
 #### public_options
 
-You can pass data as a hash to your custom isolate component with the `public_options` option. This data is inside the isolate component accessible via a hash with indifferent access, for example `public_options[:item_id]`. All data contained in the `public_options` will be passed as json to the corresponding vue component, which means this data is visible on the client side as it is rendered in the vue component config. So be careful what data you pass into `public_options`!
+You can pass data as a hash to your custom isolate component with the `public_options` option. This data is inside the isolate component accessible via a hash with indifferent access, for example `public_options[:item_id]`. All data contained in the `public_options` will be passed as json to the corresponding Vue.js component, which means this data is visible on the client side as it is rendered in the Vue.js component config. So be careful what data you pass into `public_options`!
 
 Due to the isolation of the component the data needs to be stored on the client side as to encapsulate the component from the rest of the UI.
 For example: You want to render a collection of models in single components which should be able to rerender asynchronously without rerendering the whole UI. Since we do not rerender the whole UI there is no way the component can know which of the models it should rerender. Therefore passing for example the id in the public_options hash gives you the possibility to access the id in an async request and fetch the model again for rerendering. See below for examples.
@@ -346,7 +346,7 @@ With `init_on: 'init_time'` you can specify an event on which the isolated compo
 
 ### Example 6 - Use custom data in isolated components
 
-Like described above it is possible to use custom data in your isolated components. Just pass them as a hash to `public_options` and use them in your isolated component. Be careful, because `public_options` are visible in the raw html response from the server as they get passed to a vue component.
+Like described above it is possible to use custom data in your isolated components. Just pass them as a hash to `public_options` and use them in your isolated component. Be careful, because `public_options` are visible in the raw html response from the server as they get passed to a Vue.js component.
 
 Lets render a collection of models and each of them should rerender when a user clicks a corresponding refresh button. Our model is called `Match`, representing a soccer match. It has an attribute called score with the current match score.
 
@@ -401,5 +401,5 @@ end
 ```
 
 This page will render a match_isolated_score component for each match.
-If one of the isolated components gets rerendered we need the id in order to fetch the correct match. Because the server only resolves the isolated component instead of the whole UI it does not know which match exactly is requested unless the client requests a rerender with the match id. This is why `public_options` options are passed to the client side vue component.
+If one of the isolated components gets rerendered we need the id in order to fetch the correct match. Because the server only resolves the isolated component instead of the whole UI it does not know which match exactly is requested unless the client requests a rerender with the match id. This is why `public_options` options are passed to the client side Vue.js component.
 So if match two should be rerendered the client requests the match_isolated_score component with `public_options: { id: 2 }`. With this information our isolated component can fetch the match and rerender itself.

--- a/docs/api/000-base/README.md
+++ b/docs/api/000-base/README.md
@@ -52,10 +52,10 @@ wrapping elements by default.
 #### VueJsComponent
 
 In order to equip a Ruby component with some JavaScript, we associate
-the Ruby component with a VueJs JavaScript component. The Ruby component therefore needs to inherit
+the Ruby component with a Vue.js JavaScript component. The Ruby component therefore needs to inherit
 from `Matestack::Ui::VueJsComponent`. Matestack will then render a HTML component
 tag with some special attributes and props around the response defined in the
-Ruby component. The VueJs JavaScript component (defined in a separate JavaScript file and
+Ruby component. The Vue.js JavaScript component (defined in a separate JavaScript file and
 managed via Sprockets or Webpacker) will treat the response of the Ruby
 component as its template.
 
@@ -112,8 +112,8 @@ An app is a special kind of `Matestack::Ui::VueJsComponent`. Matestack will
 therefore wrap the UI defined in the `response` method with some markup enabling
 dynamic UI behavior and CSS styling.
 
-The app ships a `Vuex store` and `Vue.js event hub`, which are used by core vuejs
-components and can optionally be used by custom vuejs components in order to
+The app ships a `Vuex store` and `Vue.js event hub`, which are used by core Vue.js
+components and can optionally be used by custom Vue.js components in order to
 trigger events, manage client side date and communicate between components.
 
 Learn more about [apps](/docs/api/000-base/10-app.md)

--- a/docs/api/100-components/cable.md
+++ b/docs/api/100-components/cable.md
@@ -20,7 +20,7 @@ consumer.subscriptions.create("MatestackUiCoreChannel", {
 ## `cable(*args, &block)`
 ----
 
-Returns a vue.js driven cable component initially containing content specified by a block.
+Returns a Vue.js driven cable component initially containing content specified by a block.
 
 Imagine something like this:
 

--- a/docs/api/100-components/form.md
+++ b/docs/api/100-components/form.md
@@ -932,9 +932,9 @@ end
 
 ```
 
-## Form and other VueJs components
+## Form and other Vue.js components
 
-The child components `form_*` have to be placed within the scope of the parent `form` component, without any other VueJs component like `toggle`, `async` creating a new scope between the child component and the parent form component**
+The child components `form_*` have to be placed within the scope of the parent `form` component, without any other Vue.js component like `toggle`, `async` creating a new scope between the child component and the parent form component**
 
 
 ```ruby

--- a/docs/guides/000-installation/README.md
+++ b/docs/guides/000-installation/README.md
@@ -18,7 +18,7 @@ $ bundle install
 
 ### JavaScript Setup
 
-Matestack uses JavaScript and, in particular, [vuejs](http://vuejs.org). To include these into your existing rails app, matestack supports both, [webpack](https://webpack.js.org/)([er](https://github.com/rails/webpacker/)) and the [asset pipeline](https://guides.rubyonrails.org/asset_pipeline.html).
+Matestack uses JavaScript and, in particular, [Vue.js](http://vuejs.org). To include these into your existing rails app, matestack supports both, [webpack](https://webpack.js.org/)([er](https://github.com/rails/webpacker/)) and the [asset pipeline](https://guides.rubyonrails.org/asset_pipeline.html).
 
 Rails 6+ apps use webpacker by default. Rails 5 and below apps use the asset pipeline by default.
 
@@ -31,7 +31,7 @@ $ yarn add https://github.com/matestack/matestack-ui-core#v1.1.0
 $ yarn install
 ```
 
-This adds the npm package that provides the javascript corresponding to the matestack-ui-core ruby gem. Make sure that the npm package version matches the gem version. To find out what gem version you are using, you may use `bundle info matestack-ui-core`.
+This adds the npm package that provides the JavaScript corresponding to the matestack-ui-core ruby gem. Make sure that the npm package version matches the gem version. To find out what gem version you are using, you may use `bundle info matestack-ui-core`.
 
 Next, import 'matestack-ui-core' in your `app/javascript/packs/application.js`
 
@@ -49,7 +49,7 @@ When you update the matestack-ui-core gem, make sure to update the npm package a
 
 #### Asset Pipeline
 
-If you are using the asset pipeline, you don't need to install the separate npm package. All required javascript libraries are provided by the matestack-ui-core gem.
+If you are using the asset pipeline, you don't need to install the separate npm package. All required JavaScript libraries are provided by the matestack-ui-core gem.
 
 Require 'matestack-ui-core' in your `app/assets/javascript/application.js`
 

--- a/docs/guides/100-tutorial/00_introduction.md
+++ b/docs/guides/100-tutorial/00_introduction.md
@@ -10,7 +10,7 @@ This guide is designed for Ruby on Rails beginners, advanced and experienced dev
 
 ## What is Matestack?
 
-Matestack deeply integrates a Vue.js based UI into Ruby on Rails, offering prebuilt components. Use these prebuild components to write dynamic Web-UIs mostly in pure Ruby and with minimum effort. Matestack enables you to develop rich SPA like interfaces in no time and without touching javascript. And if you need to go deeper you can always create your own custom components to do so. 
+Matestack deeply integrates a Vue.js based UI into Ruby on Rails, offering prebuilt components. Use these prebuild components to write dynamic Web-UIs mostly in pure Ruby and with minimum effort. Matestack enables you to develop rich SPA like interfaces in no time and without touching JavaScript. And if you need to go deeper you can always create your own custom components to do so. 
 
 ## Concept
 
@@ -38,7 +38,7 @@ For nearly all existing HTML5 Tags there is a component in order to create a ui 
 
 #### `Matestack::Ui::VueJsComponent`'s
 
-VueJsComponents are more complex components. These always have a Vue.js counterpart and enable easy development of dynamic ui elements which would usually require you to write javascript code. VueJsComponents provide an abstraction so you don't have to write javascript code and instead create rich interfaces in Ruby. Visit the [components API documentation](/docs/api/100-components/) for more information about `Matestack::Ui::VueJsComponent`'s.
+VueJsComponents are more complex components. These always have a Vue.js counterpart and enable easy development of dynamic ui elements which would usually require you to write JavaScript code. VueJsComponents provide an abstraction so you don't have to write JavaScript code and instead create rich interfaces in Ruby. Visit the [components API documentation](/docs/api/100-components/) for more information about `Matestack::Ui::VueJsComponent`'s.
 
 ## Recap & outlook
 

--- a/docs/guides/100-tutorial/06_async_component.md
+++ b/docs/guides/100-tutorial/06_async_component.md
@@ -65,7 +65,7 @@ But how can we easily update the list, when the delete action was successful? Re
 
 ## Rerender list when person is deleted
 
-When a person is deleted an event is emitted, but nothing more happens, but we want to update the list of persons, so we no longer see the deleted person in the list. In order to achieve this we could write some javascript which would manipulate the dom or we can use matestacks `async` component and get the result we want in no time and without touching any javascript. Okay, so let's update our index page like this:
+When a person is deleted an event is emitted, but nothing more happens, but we want to update the list of persons, so we no longer see the deleted person in the list. In order to achieve this we could write some JavaScript which would manipulate the dom or we can use matestacks `async` component and get the result we want in no time and without touching any JavaScript. Okay, so let's update our index page like this:
 
 ```ruby
 class Demo::Pages::Persons::Index
@@ -125,6 +125,6 @@ git add . && git commit -m "add delete button to person list and update it dynam
 
 ## Recap & outlook
 
-We added a delete button to our person list on the index page. When a person is deleted our list gets automatically updated without even reloading the page, just by updating the part that is needed. And all of that with a few lines of code and without writing any javascript.
+We added a delete button to our person list on the index page. When a person is deleted our list gets automatically updated without even reloading the page, just by updating the part that is needed. And all of that with a few lines of code and without writing any JavaScript.
 
 Take a well deserved rest and make sure to come back to the next part of this series, introducing [partials and custom components](/docs/guides/100-tutorial/07_partials_and_custom_components.md).

--- a/docs/guides/100-tutorial/08_collection_async.md
+++ b/docs/guides/100-tutorial/08_collection_async.md
@@ -208,7 +208,7 @@ Run `rails s` and head over to [localhost:3000](http://localhost:3000/) to and c
 
 ## Deep dive into the `collection` component
 
-So we have come quite a way from simply displaying all the `person` records in a plain list, right? By making use of the `collection` component and adding the necessary configuration, the person index page content is now searchable, orderable and paginated! This would have required us to write a lot of javascript and a complex controller action, but with matestack `collection` component we could do it all just with a few lines of ruby.
+So we have come quite a way from simply displaying all the `person` records in a plain list, right? By making use of the `collection` component and adding the necessary configuration, the person index page content is now searchable, orderable and paginated! This would have required us to write a lot of JavaScript and a complex controller action, but with matestack `collection` component we could do it all just with a few lines of ruby.
 
 The `collection` component was created with exactly this use case in mind - you got a collection of data (e.g. from ActiveRecord) that needs to be displayed in a filterable, ordered and paginated fashion (list, table, cards) without forcing you to write a lot of (repetitive, yet complex) logic.
 
@@ -250,4 +250,4 @@ We learned how to use matestacks `collection` component to generate a filterable
 
 So what's left? In the upcoming guides, you will create your own Vue.js components and learn about other topics like styling, notifications and authorization that are part of modern web applications
 
-So stay tuned and, once ready, head over to the next part, covering [vue.js components](/docs/guides/100-tutorial/09_dynamic_components.md) for powerful custom components.
+So stay tuned and, once ready, head over to the next part, covering [Vue.js components](/docs/guides/100-tutorial/09_dynamic_components.md) for powerful custom components.

--- a/docs/guides/100-tutorial/09_custom_vue_js_components.md
+++ b/docs/guides/100-tutorial/09_custom_vue_js_components.md
@@ -1,4 +1,4 @@
-# Essential Guide 9: Custom vue.js components
+# Essential Guide 9: Custom Vue.js components
 
 Demo: [Matestack Demo](https://demo.matestack.io)<br>
 Github Repo: [Matestack Demo Application](https://github.com/matestack/matestack-demo-application)
@@ -7,10 +7,10 @@ Welcome to the ninth part of our tutorial about building a web application with 
 
 ## Introduction
 
-In a [previous guide](/docs/guides/100-tutorial/08_collection_async.md), we introduced custom components. In this one, we're bringing it to the next level with custom vue.js components!
+In a [previous guide](/docs/guides/100-tutorial/08_collection_async.md), we introduced custom components. In this one, we're bringing it to the next level with custom Vue.js components!
 
 In this guide, we will
-- add a custom vue.js component that fetches and displays data from a third-party API
+- add a custom Vue.js component that fetches and displays data from a third-party API
 
 ## Prerequisites
 
@@ -20,9 +20,9 @@ We expect you to have successfully finished the [previous guide](/docs/guides/10
 
 We want to display an option for what you could do with the person at its show page. Therefore we want to fetch a json api and display content of the responses on the page.
 
-We can achieve this by creating a custom vue.js component. A custom vue.js component is different from a custom component in the way that it needs a corresponding javascript file, which implements the frontend counterpart of our custom vue.js component.
+We can achieve this by creating a custom Vue.js component. A custom Vue.js component is different from a custom component in the way that it needs a corresponding javascript file, which implements the frontend counterpart of our custom Vue.js component.
 
-Okay, let's create our custom vue.js component. First we create a component in `app/matestack/components/persons/activity.rb`.
+Okay, let's create our custom Vue.js component. First we create a component in `app/matestack/components/persons/activity.rb`.
 
 ```ruby
 class Components::Persons::Activity < Matestack::Ui::VueJsComponent
@@ -46,10 +46,10 @@ class Components::Persons::Activity < Matestack::Ui::VueJsComponent
 end
 ```
 
-Our vue.js component renders a div containing a paragraph and a list. The paragraph contains some text and a button. We set a `v-on:click` event handler like you would normally do in vue.js with its shorter version `@click`. This means the button will call the `addActivity` method from its corresponding vue.js component. In the list below we assume that our javascript vue.js component has an `activities` array. We loop over it, again using vue.js directives and display each activity with a button labelled 'Remove' which calls `deleteActivity(index)` if clicked.
+Our Vue.js component renders a div containing a paragraph and a list. The paragraph contains some text and a button. We set a `v-on:click` event handler like you would normally do in Vue.js with its shorter version `@click`. This means the button will call the `addActivity` method from its corresponding Vue.js component. In the list below we assume that our javascript Vue.js component has an `activities` array. We loop over it, again using Vue.js directives and display each activity with a button labelled 'Remove' which calls `deleteActivity(index)` if clicked.
 
 Like stated above, a `Matestack::Ui::VueJsComponent` requires a javascript counterpart.
-Inside we define a vue.js component and give it a name. The name needs to equal the name we defined in our ruby component at the top with `vue_js_component_name`. This settings is necessary in order to connect the javascript component with our ruby component.
+Inside we define a Vue.js component and give it a name. The name needs to equal the name we defined in our ruby component at the top with `vue_js_component_name`. This settings is necessary in order to connect the javascript component with our ruby component.
 Let's create it aside our ruby component in `app/matestack/components/persons/activity.js`
 
 ```javascript
@@ -79,7 +79,7 @@ MatestackUiCore.Vue.component('person-activity', {
 });
 ```
 
-As you can see, we're making use of [The Bored API](https://boredapi.com) to fill an (initially empty) array with strings. The `addActivity` method calls the api and pushes the activity from the response into the activities array. Because vue.js is reactive, our list specified in the ruby component will be updated and contain the added activity. Clicking the delete button will remove the activity and therefore remove the entry from the list.
+As you can see, we're making use of [The Bored API](https://boredapi.com) to fill an (initially empty) array with strings. The `addActivity` method calls the api and pushes the activity from the response into the activities array. Because Vue.js is reactive, our list specified in the ruby component will be updated and contain the added activity. Clicking the delete button will remove the activity and therefore remove the entry from the list.
 
 After creating the new component, we still need to register it, both in the `/app/matestack/components/registry.rb`
 
@@ -142,9 +142,9 @@ Again, don't forget to save your progress to Git. In the repo root, run
 git add . && git commit -m "Add activity dynamic component to display activities from The Bored API"
 ```
 
-## More information on custom vue.js components
+## More information on custom Vue.js components
 
-The existing components inside matestack aim to cover as many use cases as possible, abstracting away most of the JavaScript for generic, recurring use cases. This way, you can stick to Ruby logic and focus on building business logic instead of re-implementing basic JavaScript functionality. There sometimes is, however, a valid case for specific, handcrafted client side functionality. Therefore, matestack offers the option of creating custom vue.js components. Go ahead and [check the Vue.js guides](https://vuejs.org/v2/guide/) if you have never used it before.
+The existing components inside matestack aim to cover as many use cases as possible, abstracting away most of the JavaScript for generic, recurring use cases. This way, you can stick to Ruby logic and focus on building business logic instead of re-implementing basic JavaScript functionality. There sometimes is, however, a valid case for specific, handcrafted client side functionality. Therefore, matestack offers the option of creating custom Vue.js components. Go ahead and [check the Vue.js guides](https://vuejs.org/v2/guide/) if you have never used it before.
 
 As with custom components, there are hardly any limits for your creativity. You can also
 - use `haml` (and in the future `slim` and `erb`) for templating
@@ -156,6 +156,6 @@ To learn more, check out the [basic building blocks](/docs/guides/200-200-basic_
 
 ## Recap & outlook
 
-In this guide, we introduced custom vue.js components - an option for you to bring more complex JavaScript functionality to your application by extending matestacks components with your own Vue.js components.
+In this guide, we introduced custom Vue.js components - an option for you to bring more complex JavaScript functionality to your application by extending matestacks components with your own Vue.js components.
 
 Let's go ahead and learn how to best add [styling and notifications](/docs/guides/100-tutorial/10_styling_notifications.md) to our application in the next part of the series!

--- a/docs/guides/100-tutorial/09_custom_vue_js_components.md
+++ b/docs/guides/100-tutorial/09_custom_vue_js_components.md
@@ -20,7 +20,7 @@ We expect you to have successfully finished the [previous guide](/docs/guides/10
 
 We want to display an option for what you could do with the person at its show page. Therefore we want to fetch a json api and display content of the responses on the page.
 
-We can achieve this by creating a custom Vue.js component. A custom Vue.js component is different from a custom component in the way that it needs a corresponding javascript file, which implements the frontend counterpart of our custom Vue.js component.
+We can achieve this by creating a custom Vue.js component. A custom Vue.js component is different from a custom component in the way that it needs a corresponding JavaScript file, which implements the frontend counterpart of our custom Vue.js component.
 
 Okay, let's create our custom Vue.js component. First we create a component in `app/matestack/components/persons/activity.rb`.
 
@@ -46,10 +46,10 @@ class Components::Persons::Activity < Matestack::Ui::VueJsComponent
 end
 ```
 
-Our Vue.js component renders a div containing a paragraph and a list. The paragraph contains some text and a button. We set a `v-on:click` event handler like you would normally do in Vue.js with its shorter version `@click`. This means the button will call the `addActivity` method from its corresponding Vue.js component. In the list below we assume that our javascript Vue.js component has an `activities` array. We loop over it, again using Vue.js directives and display each activity with a button labelled 'Remove' which calls `deleteActivity(index)` if clicked.
+Our Vue.js component renders a div containing a paragraph and a list. The paragraph contains some text and a button. We set a `v-on:click` event handler like you would normally do in Vue.js with its shorter version `@click`. This means the button will call the `addActivity` method from its corresponding Vue.js component. In the list below we assume that our JavaScript Vue.js component has an `activities` array. We loop over it, again using Vue.js directives and display each activity with a button labelled 'Remove' which calls `deleteActivity(index)` if clicked.
 
-Like stated above, a `Matestack::Ui::VueJsComponent` requires a javascript counterpart.
-Inside we define a Vue.js component and give it a name. The name needs to equal the name we defined in our ruby component at the top with `vue_js_component_name`. This settings is necessary in order to connect the javascript component with our ruby component.
+Like stated above, a `Matestack::Ui::VueJsComponent` requires a JavaScript counterpart.
+Inside we define a Vue.js component and give it a name. The name needs to equal the name we defined in our ruby component at the top with `vue_js_component_name`. This settings is necessary in order to connect the JavaScript component with our ruby component.
 Let's create it aside our ruby component in `app/matestack/components/persons/activity.js`
 
 ```javascript

--- a/docs/guides/100-tutorial/10_styling_notifications.md
+++ b/docs/guides/100-tutorial/10_styling_notifications.md
@@ -7,7 +7,7 @@ Welcome to the tenth part of our tutorial about building a web application with 
 
 ## Introduction
 
-After introducing vue.js components in the [previous guide](/docs/guides/100-tutorial/09_custom_vue_js_components.md), it's time to work on the appearance and user experience of the application.
+After introducing Vue.js components in the [previous guide](/docs/guides/100-tutorial/09_custom_vue_js_components.md), it's time to work on the appearance and user experience of the application.
 
 In this guide, we will
 - install and set up the popular UI toolkit [Bootstrap](https://getbootstrap.com/)
@@ -42,7 +42,7 @@ import 'css/custom-bootstrap'
 
 Bootstrap requires jQuery and popper.js, so now is a good time to add those dependencies. Install it by runnning `yarn add jquery popper.js`.
 
-Afterwards import all javascript dependencies of bootstrap and bootstraps own javascript in the `app/javascript/packs/application.js` by adding the following lines to it.
+Afterwards import all JavaScript dependencies of bootstrap and bootstraps own JavaScript in the `app/javascript/packs/application.js` by adding the following lines to it.
 
 ```js
 import 'jquery'

--- a/docs/guides/100-tutorial/13_wrap_up.md
+++ b/docs/guides/100-tutorial/13_wrap_up.md
@@ -9,7 +9,7 @@ Welcome to the thirteenth part of our tutorial about building a web application 
 
 What have we got so far? After following the previous guides, there's now a `RubyOnRails` application running on `Heroku` with a public and admin area allowing for basic CRUD operations.
 
-We have achieved this by setting up two matestack apps each with some matestack pages and by orchestrating matestacks components and vue.js components.
+We have achieved this by setting up two matestack apps each with some matestack pages and by orchestrating matestacks components and Vue.js components.
 
 One of the matestack apps is only available after an admin has logged in and protected by the `Devise` gem. The application pleases the eye and offers a great user experience since we have set up and customized `Bootstrap`. Assets are being served by `Webpacker`.
 

--- a/docs/guides/1000-action_cable/README.md
+++ b/docs/guides/1000-action_cable/README.md
@@ -64,7 +64,7 @@ If you do not want to use the rails generator just create the `matestack_ui_core
 
 ## Usage
 
-After setting up the client side javascript for our action cable we now take a look at how to create server side events to trigger for example rerenderings of `async`/isolated components or show/hide content with the `toggle` component. We will introduce two different types of creating server side events. First broadcasting events to all subscribed clients and secondly sending events to a user by authenticating a connection through a devise user.
+After setting up the client side JavaScript for our action cable we now take a look at how to create server side events to trigger for example rerenderings of `async`/isolated components or show/hide content with the `toggle` component. We will introduce two different types of creating server side events. First broadcasting events to all subscribed clients and secondly sending events to a user by authenticating a connection through a devise user.
 
 ### Broadcast
 
@@ -244,4 +244,4 @@ PrivateChannel.broadcast_to(user, {
 
 ## Conclusion
 
-Creating channels and connections can be done like you want. To learn more about all the possibilities read Rails Guide about [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html). Important for the use with matestack is to emit events in the javascript `received(data)` callback and have a clear structure to determine what the name of the event is which should be emitted. Like shown above we recommend using an `:event` key in your websocket broadcast, which represents the event name that gets emitted through the event hub. You optionally can pass all the received data as payload to that event or also use a specific key. As this is optional you don't need to pass any data to the event emit.
+Creating channels and connections can be done like you want. To learn more about all the possibilities read Rails Guide about [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html). Important for the use with matestack is to emit events in the JavaScript `received(data)` callback and have a clear structure to determine what the name of the event is which should be emitted. Like shown above we recommend using an `:event` key in your websocket broadcast, which represents the event name that gets emitted through the event hub. You optionally can pass all the received data as payload to that event or also use a specific key. As this is optional you don't need to pass any data to the event emit.

--- a/docs/guides/1500-contribute/README.md
+++ b/docs/guides/1500-contribute/README.md
@@ -51,7 +51,7 @@ Visit `localhost:3000/sandbox/hello` in order to visit the sandbox page. It live
 Visit `localhost:3000/my_app/my_first_page` in order to visit some example use cases. The pages live in `spec/dummy/app/matestack/pages/my_app`.
 
 ### Run the Webpack Watcher
-The builder app located in `builder/` uses webpacker in order build matestacks Javascript based on the source code found in `app/`. During development it can be used to compile the javascript when any relevant source code is changed. Run it like seen below:
+The builder app located in `builder/` uses webpacker in order build matestacks Javascript based on the source code found in `app/`. During development it can be used to compile the JavaScript when any relevant source code is changed. Run it like seen below:
 
 ```shell
 docker-compose up webpack-watcher

--- a/docs/guides/200-basic_building_blocks/README.md
+++ b/docs/guides/200-basic_building_blocks/README.md
@@ -60,7 +60,7 @@ Apps need to inherit from `Matestack::Ui::App` and implement a `response` method
 
 How the call of `heading text: "Matestack Shop"` works will be explained later in this guide.
 
-As you might have read in the [installation](/docs/guides/000-installation/) guide you need to have a rails layout containing a html element with "matestack-ui" as class name. This is required because matestack uses vue.js and we mount to this class name. Because we do not yet support writing "html, head, meta" and other tags that are used outside the body in matestack you need at least one layout file. But we recommend using one layout file for each app.
+As you might have read in the [installation](/docs/guides/000-installation/) guide you need to have a rails layout containing a html element with "matestack-ui" as class name. This is required because matestack uses Vue.js and we mount to this class name. Because we do not yet support writing "html, head, meta" and other tags that are used outside the body in matestack you need at least one layout file. But we recommend using one layout file for each app.
 
 **Accessing data in apps**
 
@@ -176,7 +176,7 @@ Components are reusable UI parts. They can represent simple parts like a button 
 
 Above we used methods like `heading`, `paragraph`, `small` and `div`. These are all what we call core components provided trough a core component registry which is automatically loaded. They are components representing the corresponding html tag. For example calling `div` would result after rendering in `<div></div>`. Matestack provides a always expanding wide set of w3c's specified html tags for you, so you could write UIs in pure ruby. All available components are listed in our [components api](/docs/api/100-components/).
 
-There are two different types of core components. Simple components and so called vue.js components. `div` for example is a simple component, it renders a "div" tag either emtpy or containing the content given by a block. `toggle` on the other hand is a vue.js component, because it comes with a corresponding vue.js component to enable dynamic behavior on the client side. `toggle` for example can show or hide content depending on events, enabling you to write such dynamic behavior without writing anything else than ruby.
+There are two different types of core components. Simple components and so called Vue.js components. `div` for example is a simple component, it renders a "div" tag either emtpy or containing the content given by a block. `toggle` on the other hand is a Vue.js component, because it comes with a corresponding Vue.js component to enable dynamic behavior on the client side. `toggle` for example can show or hide content depending on events, enabling you to write such dynamic behavior without writing anything else than ruby.
 
 **Using core components**
 
@@ -312,7 +312,7 @@ Read more about how properties work and how it prevents overwriting other method
 
 #### Creating own Vue.js components
 
-For most cases you will not need to create custom Vue.js components, but if you need custom javascript behavior you can implement it by using a custom Vue.js component. It only differs slightly from components. They also need to implement a `response` method and use properties to access data but they inherit from `Matestack::Ui::VueJsComponent` and require a javascript file implementing the corresponding frontend component. In order to link these they require you to set a Vue.js component name. Let's take a look at an example Vue.js component:
+For most cases you will not need to create custom Vue.js components, but if you need custom JavaScript behavior you can implement it by using a custom Vue.js component. It only differs slightly from components. They also need to implement a `response` method and use properties to access data but they inherit from `Matestack::Ui::VueJsComponent` and require a JavaScript file implementing the corresponding frontend component. In order to link these they require you to set a Vue.js component name. Let's take a look at an example Vue.js component:
 
 `app/matestack/components/products/image_slider.rb`
 
@@ -356,18 +356,18 @@ MatestackUiCore.Vue.component('products-image-slider', {
 })
 ```
 
-Implementing the javascript component works as you would normally implement your Vue.js component. Head over to the [Vue.js docs]() to learn more about vue.js. 
+Implementing the JavaScript component works as you would normally implement your Vue.js component. Head over to the [Vue.js docs]() to learn more about Vue.js. 
 
-To use this component remember to add it like the product teaser to a registry. Also you need to add the javascript file to webpacker or the asset pipeline. To learn how to do that or if you want to know more about Vue.js components take a look at the [Vue.js component api](/docs/api/000-base/30-vue_js_component.md).
+To use this component remember to add it like the product teaser to a registry. Also you need to add the JavaScript file to webpacker or the asset pipeline. To learn how to do that or if you want to know more about Vue.js components take a look at the [Vue.js component api](/docs/api/000-base/30-vue_js_component.md).
 
 
 ## Event Hub
 
-Matestack uses events as a communication layer to enable features of core Vue.js components. It offers an event hub which is accessible to you. Reacting to events in javascript or triggering your own events is therefore possible.
+Matestack uses events as a communication layer to enable features of core Vue.js components. It offers an event hub which is accessible to you. Reacting to events in JavaScript or triggering your own events is therefore possible.
 
 There are some core Vue.js components that can react to events and some that can emit events. For example a `toggle` component can be configured to show its content when a certain event appears. Combine it with an `onclick` component which can emit events when its content is clicked and you could create a collapsable content component without writing anything else than ruby.
 
-So reacting to events or triggering them can be done with the core Vue.js components. But if you want to react to events or trigger them yourself for example in a customVvue.js component you can do this as shown below.
+So reacting to events or triggering them can be done with the core Vue.js components. But if you want to react to events or trigger them yourself for example in a custom Vue.js component you can do this as shown below.
 
 ```js
 // use MatestackUiCore.matestackEventHub.$emit(event_name, optional_payload)
@@ -379,14 +379,14 @@ MatestackUiCore.matestackEventHub.$emit('my-event', { some: 'optional data' })
 MatestackUiCore.matestackEventHub.$on('my-event', reactToEvent)
 ```
 
-Matestack also uses events to give you the option to hook into some processes like page loading and run custom javascript, for example to trigger complex page transition animations, but there is an easier way for simple page transitions animations.
+Matestack also uses events to give you the option to hook into some processes like page loading and run custom JavaScript, for example to trigger complex page transition animations, but there is an easier way for simple page transitions animations.
 
 To learn more about the event hub head over to our [event hub api](/docs/api/000-base/50-event_hub.md)
 
 
 ## Core Features
 
-You learned about matestack apps, pages, components, custom components, custom Vue.js components, the event hub and you have heard about matestacks core Vue.js components. They are Vue.js components that implement useful features which would else require you to write javascript. Following up is a short introduction to matestacks unique components that enable you to write rich, modern UIs with ease.
+You learned about matestack apps, pages, components, custom components, custom Vue.js components, the event hub and you have heard about matestacks core Vue.js components. They are Vue.js components that implement useful features which would else require you to write JavaScript. Following up is a short introduction to matestacks unique components that enable you to write rich, modern UIs with ease.
 
 **transition**
 

--- a/docs/guides/200-basic_building_blocks/README.md
+++ b/docs/guides/200-basic_building_blocks/README.md
@@ -310,9 +310,9 @@ If you call a component and forget a required property matestack will throw a `M
 
 Read more about how properties work and how it prevents overwriting other methods at the [component api](/docs/api/000-base/10-component.md#passing-options-to-components).
 
-#### Creating own vue.js components
+#### Creating own Vue.js components
 
-For most cases you will not need to create custom vue.js components, but if you need custom javascript behavior you can implement it by using a custom vue.js component. It only differs slightly from components. They also need to implement a `response` method and use properties to access data but they inherit from `Matestack::Ui::VueJsComponent` and require a javascript file implementing the corresponding frontend component. In order to link these they require you to set a vue.js component name. Let's take a look at an example vue.js component:
+For most cases you will not need to create custom Vue.js components, but if you need custom javascript behavior you can implement it by using a custom Vue.js component. It only differs slightly from components. They also need to implement a `response` method and use properties to access data but they inherit from `Matestack::Ui::VueJsComponent` and require a javascript file implementing the corresponding frontend component. In order to link these they require you to set a Vue.js component name. Let's take a look at an example Vue.js component:
 
 `app/matestack/components/products/image_slider.rb`
 
@@ -335,7 +335,7 @@ class Components::Products::ImageSlider < Matestack::Ui::VueJsComponent
 end
 ```
 
-We put the necessary vue.js component in the same directory beneath our ruby component. In this file we create our vue component and link it to our ruby component by specifying `vue_js_component_name` inside our ruby component to match the component name we gave our vue component. In this case "products-image-slider".
+We put the necessary Vue.js component in the same directory beneath our ruby component. In this file we create our Vue.js component and link it to our ruby component by specifying `vue_js_component_name` inside our ruby component to match the component name we gave our Vue.js component. In this case "products-image-slider".
 
 `app/matestack/components/products/image_slider.js`
 
@@ -356,18 +356,18 @@ MatestackUiCore.Vue.component('products-image-slider', {
 })
 ```
 
-Implementing the javascript component works as you would normally implement your vue.js component. Head over to the [vue.js docs]() to learn more about vue.js. 
+Implementing the javascript component works as you would normally implement your Vue.js component. Head over to the [Vue.js docs]() to learn more about vue.js. 
 
-To use this component remember to add it like the product teaser to a registry. Also you need to add the javascript file to webpacker or the asset pipeline. To learn how to do that or if you want to know more about vue.js components take a look at the [vue.js component api](/docs/api/000-base/30-vue_js_component.md).
+To use this component remember to add it like the product teaser to a registry. Also you need to add the javascript file to webpacker or the asset pipeline. To learn how to do that or if you want to know more about Vue.js components take a look at the [Vue.js component api](/docs/api/000-base/30-vue_js_component.md).
 
 
 ## Event Hub
 
-Matestack uses events as a communication layer to enable features of core vue.js components. It offers an event hub which is accessible to you. Reacting to events in javascript or triggering your own events is therefore possible.
+Matestack uses events as a communication layer to enable features of core Vue.js components. It offers an event hub which is accessible to you. Reacting to events in javascript or triggering your own events is therefore possible.
 
-There are some core vue.js components that can react to events and some that can emit events. For example a `toggle` component can be configured to show its content when a certain event appears. Combine it with an `onclick` component which can emit events when its content is clicked and you could create a collapsable content component without writing anything else than ruby.
+There are some core Vue.js components that can react to events and some that can emit events. For example a `toggle` component can be configured to show its content when a certain event appears. Combine it with an `onclick` component which can emit events when its content is clicked and you could create a collapsable content component without writing anything else than ruby.
 
-So reacting to events or triggering them can be done with the core vue.js components. But if you want to react to events or trigger them yourself for example in a custom vue.js component you can do this as shown below.
+So reacting to events or triggering them can be done with the core Vue.js components. But if you want to react to events or trigger them yourself for example in a customVvue.js component you can do this as shown below.
 
 ```js
 // use MatestackUiCore.matestackEventHub.$emit(event_name, optional_payload)
@@ -386,7 +386,7 @@ To learn more about the event hub head over to our [event hub api](/docs/api/000
 
 ## Core Features
 
-You learned about matestack apps, pages, components, custom components, custom vue.js components, the event hub and you have heard about matestacks core vue.js components. They are vue.js components that implement useful features which would else require you to write javascript. Following up is a short introduction to matestacks unique components that enable you to write rich, modern UIs with ease.
+You learned about matestack apps, pages, components, custom components, custom Vue.js components, the event hub and you have heard about matestacks core Vue.js components. They are Vue.js components that implement useful features which would else require you to write javascript. Following up is a short introduction to matestacks unique components that enable you to write rich, modern UIs with ease.
 
 **transition**
 

--- a/docs/guides/300-rails_integration/README.md
+++ b/docs/guides/300-rails_integration/README.md
@@ -94,7 +94,7 @@ Now we can use our matestack component in our view. Replacing the `render partia
 <% end %>
 ```
 
-This approach gives you access inside this component to all matestack features except page transitions. You can use `async`, `toggle`, `collection`, `actions`, `forms`, `isolated`, `onclick` and more vue.js components inside your components, enabling you to build modern and interactive UIs in pure ruby, while keeping a low effort for integrating or slowly migrating your project to matestack.
+This approach gives you access inside this component to all matestack features except page transitions. You can use `async`, `toggle`, `collection`, `actions`, `forms`, `isolated`, `onclick` and more Vue.js components inside your components, enabling you to build modern and interactive UIs in pure ruby, while keeping a low effort for integrating or slowly migrating your project to matestack.
 
 To use matestack page transition feature you have to use matestack pages inside a matestack app. 
 


### PR DESCRIPTION
# Changes

- [X] Within the documentation, there were various references to Vue.js (`VueJS`, `vue`, `vuejs`, `vue.js`). I tried to replace them all with the official naming which, to my best knowledge, is `Vue.js`.