### PR TITLE
Restructure event_hub.md markdown headings

### DIFF
--- a/docs/api/000-base/50-event_hub.md
+++ b/docs/api/000-base/50-event_hub.md
@@ -1,8 +1,8 @@
-### Event Hub
+# Event Hub
 
 Matestack offers an event hub, which can be used to communicate between components.
 
-#### Emitting events
+## Emitting events
 
 `app/matestack/components/some_component.js`
 
@@ -20,7 +20,7 @@ MatestackUiCore.Vue.component('some-component', {
 
 Use `MatestackUiCore.matestackEventHub.$emit(EVENT_NAME, OPTIONAL PAYLOAD)`
 
-#### Receiving events
+## Receiving events
 
 `app/matestack/components/some_component.js`
 


### PR DESCRIPTION
### Changes

- [X] [Eventhub documentation](https://docs.matestack.io/docs/api/000-base/50-event_hub.md) is not correctly formatted, perhaps since it was split from a bigger file in the past. This PR tries to replicate the heading structure from other files in `docs/api/000-base/`.

Current state:
![Screenshot_2020-10-19 Matestack Documentation(1)](https://user-images.githubusercontent.com/16822008/96500271-84cd7480-1246-11eb-8bf3-f399090956b7.png)
