### PR TITLE
Fix a typo

### DIFF
--- a/docs/reactive_components/README.md
+++ b/docs/reactive_components/README.md
@@ -149,4 +149,4 @@ Read more about the [isolated component](/docs/reactive_components/600-isolated/
 
 With the `collection` component you can display active record model or similar collections and add features like filtering, paginating and ordering with ease. Each of these features requires no page reload to take effect, because the `collection` component leverages a `async` component in combination with the event hub to only reload the effected content of the collection. The `collection` component is a bit more complex as it offers a lot of functionality, that's why we will not explain the rudimentary usage here.
 
-Take a look at the [collection component guide](/docs//guides/700-collection/README.md) to learn how it works and how to use it.
+Take a look at the [collection component guide](/docs/guides/700-collection/README.md) to learn how it works and how to use it.


### PR DESCRIPTION
The URL to "collection component guide" had an extra slash in it which seemed to break the link.

**Note:** If you submit a feature or bugfix PR, pick **develop** as target branch (and delete this line afterwards).

## Issue https://github.com/matestack/matestack-ui-core/issues/XXX: Short description here

### Changes

- [ ] Describe the changes in one or more bulletpoints

### Notes

- Let the reviewers know something special
