### PR TITLE
Custom classes for true/false checkboxes

### DIFF
--- a/app/concepts/matestack/ui/core/form/checkbox/checkbox.rb
+++ b/app/concepts/matestack/ui/core/form/checkbox/checkbox.rb
@@ -26,7 +26,13 @@ module Matestack::Ui::Core::Form::Checkbox
         # checked/unchecked checkbox
       else
         form_input type: :hidden, key: key, value: (false_value || 0), errors: false
-        form_input type: :checkbox, key: key, value: checked_value, id: id_for_item(value), errors: false
+        form_input html_attributes.merge(
+          type: :checkbox, 
+          key: key, 
+          value: checked_value, 
+          id: id_for_item(value), 
+          errors: false
+        )
         label text: input_label, for: id_for_item(value)
       end
       render_errors

--- a/spec/test/components/dynamic/form/checkbox/checkbox_spec.rb
+++ b/spec/test/components/dynamic/form/checkbox/checkbox_spec.rb
@@ -172,7 +172,7 @@ describe "Form Component", type: :feature, js: true do
 
         def response
           form form_config, :include do
-            form_checkbox id: "my-array-test-checkbox", key: :status, label: 'Status'
+            form_checkbox id: "my-array-test-checkbox", key: :status, label: 'Status', class: 'test'
             form_submit do
               button text: "Submit me!"
             end
@@ -196,6 +196,7 @@ describe "Form Component", type: :feature, js: true do
 
       visit "/example"
       expect(page).to have_field('Status', checked: false)
+      expect(page).to have_css('input.test')
 
       check 'Status'
       click_button "Submit me!"


### PR DESCRIPTION
## Issue https://github.com/matestack/matestack-ui-core/issues/490: 

Using `html_attributes` for true/false checkboxes

closes #490 