### PR TITLE
Fixed Vue.js browser console error with inital templates containing forms

### DIFF
--- a/app/concepts/matestack/ui/core/cable/cable.haml
+++ b/app/concepts/matestack/ui/core/cable/cable.haml
@@ -1,4 +1,4 @@
-%component{dynamic_tag_attributes.merge('initial-template': "#{render_content}")}
+%component{dynamic_tag_attributes.merge('v-bind:initial-template': "#{render_content.to_json}")}
   %div{class: "matestack-cable-component-container", "v-bind:class": "{ 'loading': loading === true }"}
     %div{class: "matestack-cable-component-wrapper", "v-if": "cableTemplate != null", "v-bind:class": "{ 'loading': loading === true }"}
       %v-runtime-template{":template":"cableTemplate"}


### PR DESCRIPTION
## Issue https://github.com/matestack/matestack-ui-core/issues/497: Cable component throws error when form included

### Changes

- [x] Fixed prop injection on cable component

### Notes

- unfortunately I can't test this as I'm not getting the browsers console.log via capybara/Selenium
- tested and verified manually (needs specs really soon)
