### PR TITLE
1.3.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.1 Release
+
+### Bugfixes
+
+- Fixes #497 Cable component throws browser error when initial content contains form component
+
 ## v1.3.0 Release
 
 ### Potential breaking change

--- a/app/concepts/matestack/ui/core/cable/cable.haml
+++ b/app/concepts/matestack/ui/core/cable/cable.haml
@@ -1,4 +1,4 @@
-%component{dynamic_tag_attributes.merge('initial-template': "#{render_content}")}
+%component{dynamic_tag_attributes.merge('v-bind:initial-template': "#{render_content.to_json}")}
   %div{class: "matestack-cable-component-container", "v-bind:class": "{ 'loading': loading === true }"}
     %div{class: "matestack-cable-component-wrapper", "v-if": "cableTemplate != null", "v-bind:class": "{ 'loading': loading === true }"}
       %v-runtime-template{":template":"cableTemplate"}

--- a/lib/matestack/ui/core/version.rb
+++ b/lib/matestack/ui/core/version.rb
@@ -1,7 +1,7 @@
 module Matestack
   module Ui
     module Core
-      VERSION = '1.3.0'
+      VERSION = '1.3.1'
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matestack-ui-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "app/javascript/matestack-ui-core",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
### Bugfixes

- Fixes #497 Cable component throws browser error when initial content contains form component