### PR TITLE
quick fix #503 - pin version of vue-turbolinks to 2.1.x as 2.2 causes…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "link-module-alias": "^1.2.0",
     "v-runtime-template": "^1.5.2",
     "vue": "^2.5.17",
-    "vue-turbolinks": "^2.1.0",
+    "vue-turbolinks": "~2.1.0",
     "vuex": "^3.0.1",
     "yarn": "^1.22.0"
   },


### PR DESCRIPTION
## Issue https://github.com/matestack/matestack-ui-core/issues/503: vue-turbolinks 2.2 causes errors

### Changes

- [ ] pin version of vue-turbolinks to 2.1.x

### Notes

- Quick fix, not enough time to investigate how to create compatibility with vue-turbolinks 2.2
