### PR TITLE
fix webpacker 6.0.0 error to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "yarn": "^1.22.0"
   },
   "exports": {
+    ".": "./app/javascript/matestack-ui-core",
     "./concepts/": "./app/concepts/matestack/ui/core/"
   },
   "scripts": {


### PR DESCRIPTION


## Issue https://github.com/matestack/matestack-ui-core/issues/500: webpacker 6.0.0 failed to compile matestack-ui

### Changes

- [ ] inserted new path in exports field inside package.json

