### PR TITLE
Feature: Conditionally render components with a new `render?` method.

### DIFF
--- a/docs/ui-in-pure-ruby/components/component-api.md
+++ b/docs/ui-in-pure-ruby/components/component-api.md
@@ -125,6 +125,42 @@ class SomeComponent < Matestack::Ui::Component
 end
 ```
 
+## Render?
+
+Use the `render?` method to conditionally render the component based on custom rules:
+
+```ruby
+class AdminComponent < Matestack::Ui::Component
+  required :user
+
+  def render?
+    context.user.admin?
+  end
+
+  def response
+    div id: "admin-component" do
+      plain "This component should only get rendered for admins"
+    end
+  end
+end
+```
+
+This is particularly useful to avoid plastering your views with conditional statements like `if` and `unless`.
+
+Instead of:
+
+```ruby
+  <% if current_user.admin? %>
+    <%= Components::AdminComponent.(user: current_user) %>
+  <% end %>
+```
+
+You can just use:
+
+```ruby
+  <%= Components::AdminComponent.(user: current_user) %>
+```
+
 ## Prepare
 
 Use a prepare method to resolve instance variables before rendering a component if required.

--- a/lib/matestack/ui/core/base.rb
+++ b/lib/matestack/ui/core/base.rb
@@ -12,6 +12,8 @@ module Matestack
         attr_accessor :html_tag, :text, :options, :parent, :escape, :bind_to_parent
 
         def initialize(html_tag = nil, text = nil, options = {}, &block)
+          return unless render?
+
           self.bind_to_parent = ([:without_parent].include?(html_tag) ? false : true)
           self.slots = self.options.delete(:slots) if self.options
           # extract_options(text, options) is called in properties
@@ -24,6 +26,12 @@ module Matestack
           create_children(&block)
           Matestack::Ui::Core::Context.parent = self.parent
           self
+        end
+
+        # can be optionally overwritten in subclass 
+        # in order to conditionally render the component
+        def render?
+          true
         end
 
         # check if text is given and set text and options accordingly

--- a/spec/test/base/core/component/conditional_rendering_spec.rb
+++ b/spec/test/base/core/component/conditional_rendering_spec.rb
@@ -1,0 +1,105 @@
+require_relative "../../../support/utils"
+include Utils
+
+describe "Component", type: :feature, js: true do
+
+  before :all do
+    class ComponentTestController < ActionController::Base
+      include Matestack::Ui::Core::Helper
+      layout "application"
+
+      def my_action
+        render ExamplePage
+      end
+    end
+
+    Rails.application.routes.append do
+      scope "component_conditional_rendering_spec" do
+        get '/component_test', to: 'component_test#my_action', as: 'conditional_component_test_action'
+      end
+    end
+    Rails.application.reload_routes!
+  end
+
+  describe "conditional component" do
+
+    it "renders by default if '.render?' method is not overrided" do
+      class DefaultRenderingComponent < Matestack::Ui::Component
+        def response
+          div id: "my-component" do
+            plain "default rendering component"
+          end
+        end
+
+      register_self_as(:default_rendering_component)
+      end
+
+      class ExamplePage < Matestack::Ui::Page
+        def response
+          div id: "div-on-page" do
+            default_rendering_component
+          end
+        end
+      end
+
+      visit "component_conditional_rendering_spec/component_test"
+      expect(page).to have_xpath('//div[@id="div-on-page"]/div[@id="my-component" and contains(.,"default rendering component")]')
+    end
+
+    it "renders if '.render?' method is overrided and returns true" do
+      class ConditionalRenderingComponent < Matestack::Ui::Component
+        def response
+          div id: "my-component" do
+            plain "conditional rendering component"
+          end
+        end
+
+        def render?
+          true
+        end
+
+      register_self_as(:conditional_rendering_component)
+      end
+
+      class ExamplePage < Matestack::Ui::Page
+        def response
+          div id: "div-on-page" do
+            conditional_rendering_component
+          end
+        end
+      end
+
+      visit "component_conditional_rendering_spec/component_test"
+      expect(page).to have_xpath('//div[@id="div-on-page"]/div[@id="my-component" and contains(.,"conditional rendering component")]')
+    end
+
+    it "doesn't render if '.render?' method is overrided and returns false" do
+      class ConditionalRenderingComponent < Matestack::Ui::Component
+        def response
+          div id: "my-component" do
+            plain "conditional rendering component"
+          end
+        end
+
+        def render?
+          false
+        end
+
+      register_self_as(:conditional_rendering_component)
+      end
+
+      class ExamplePage < Matestack::Ui::Page
+        def response
+          div id: "div-on-page" do
+            conditional_rendering_component
+          end
+        end
+      end
+
+      visit "component_conditional_rendering_spec/component_test"
+      expect(page).to_not have_xpath('//div[@id="div-on-page"]/div[@id="my-component" and contains(.,"conditional rendering component")]')
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Feature: Conditionally render components with a new `render?` method.

As discussed on the Discord channel, we would like to give developers the optionality to conditionally render components without littering views with conditional statements like `if` and `unless`.

This can now get easily done by overriding the `render?` method inside the component.

Instead of:

```ruby
# some view

<% if current_user.admin? %>
  <%= Components::AdminComponent.(user: current_user) %>
<% end %>
```

It's possible to:

```ruby
# some view

<%= Components::AdminComponent.(user: current_user) %>
```

```ruby
# app/matestack/components/admin_component.rb

class AdminComponent < Matestack::Ui::Component
  required :user

  def render?
    context.user.admin?
  end

  def response
    div id: "admin-component" do
      plain "This component should only get rendered for admins"
    end
  end
end
```


### Changes

- [x] Add the `render?` method to `Matestack::Ui::Core::Base`
- [x] Add a guard clause to escape the `initialize` method on `Matestack::Ui::Core::Base` if `render?` returns false
- [x] Add spec tests
- [x] Update docs with reference to this new feature