### PR TITLE
Fix duplicate Page root element id

### DIFF
--- a/lib/matestack/ui/core/page.rb
+++ b/lib/matestack/ui/core/page.rb
@@ -27,13 +27,11 @@ module Matestack
                   end
                 end
                 div class: 'matestack-page-wrapper', 'v-bind:class': '{ "loading": loading === true }' do
-                  div 'v-if': 'asyncPageTemplate == null' do
-                    div id: page_id, class: 'matestack-page-root' do
+                  div id: page_id, class: 'matestack-page-root' do
+                    div 'v-if': 'asyncPageTemplate == null' do
                       yield
                     end
-                  end
-                  div 'v-if': 'asyncPageTemplate != null' do
-                    div id: page_id, class: 'matestack-page-root' do
+                    div 'v-if': 'asyncPageTemplate != null' do
                       Base.new('v-runtime-template', ':template': 'asyncPageTemplate')
                     end
                   end

--- a/spec/test/base/core/app/layout_spec.rb
+++ b/spec/test/base/core/app/layout_spec.rb
@@ -70,10 +70,11 @@ describe "App", type: :feature, js: true do
 
     visit "app_layout_spec/layout_page1"
     expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/h1[contains(.,"My Example App Layout")]')
-    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div/div[@class="matestack-page-root"]/div[@id="my-div-on-page-1"]/h2[contains(.,"This is Page 1")]')
+    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div[@class="matestack-page-root"]/div/div[@id="my-div-on-page-1"]/h2[contains(.,"This is Page 1")]')
+    
     visit "app_layout_spec/layout_page2"
     expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/h1[contains(.,"My Example App Layout")]')
-    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div/div[@class="matestack-page-root"]/div[@id="my-div-on-page-2"]/h2[contains(.,"This is Page 2")]')
+    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div[@class="matestack-page-root"]/div/div[@id="my-div-on-page-2"]/h2[contains(.,"This is Page 2")]')
   end
 
   it 'can use a layout file' do
@@ -113,10 +114,10 @@ describe "App", type: :feature, js: true do
       end
     end
 
-    visit "app_layout_spec/layout_page1"
-    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/h1[contains(.,"My Example App Layout")]')
-    expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div/div[@class="matestack-page-root"]/div[@id="my-div-on-page-1"]/h2[contains(.,"This is Page 1")]')
-    expect(page).to have_selector('div#from-rails-layout', visible: false)
+     visit "app_layout_spec/layout_page1"
+     expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/h1[contains(.,"My Example App Layout")]')
+     expect(page).to have_xpath('//div[@class="matestack-app-wrapper"]/main/div[@class="matestack-page-container"]/div[@class="matestack-page-wrapper"]/div[@class="matestack-page-root"]/div/div[@id="my-div-on-page-1"]/h2[contains(.,"This is Page 1")]')
+     expect(page).to have_selector('div#from-rails-layout', visible: false)
   end
 
 end


### PR DESCRIPTION
## Issue: 

Matestack by default renders two Page root elements, both containing a child `div` with the `v-if` directive, for instructing Vue.js on wether or not rendering the child element:

```html
<div id="matestack-page-controller-action" class="matestack-page-root">
  <div v-if="asyncPageTemplate == null"> 
    <!-- content -->
 </div>
</div>

<div id="matestack-page-controller-action" class="matestack-page-root">
  <div v-if="asyncPageTemplate != null"> 
    <!-- content -->
 </div>
</div>
``` 

This used to be a non-issue, but now we've added an `id` attribute to the Page's root element, containing both the controller and the action, as we can see in the example above. 

Although it doesn't appear to cause any actual problem right now, we cannot guarantee it won't cause in the future. 

Also, it's not compliant with the [HTML spec](https://html.spec.whatwg.org/multipage/dom.html#global-attributes:the-id-attribute-2), which dictates the `id` attribute must be unique.

### Changes

- [x] Remove additional instances of the Page's root element.
- [x] Make the now unique instance of the Page's root element to wrap both `div`s containing the `v-if` directive.
- [x] Update the layout spec to reflect the new code.

### Notes

- Apparently, Matestack already has this issue with the global root element `matestack-ui` , which is added to both Pages and Apps. Since Apps can wrap Pages, we can have the situation of two elements with the very same `id` attribute. This PR does not fix this other issue, but I'll start a conversation with the maintainers about that.