### PR TITLE
Issue 549

### DIFF
--- a/lib/matestack/ui/vue_js/components/async.js
+++ b/lib/matestack/ui/vue_js/components/async.js
@@ -113,4 +113,3 @@ const componentDef = {
 let component = Vue.component('matestack-ui-core-async', componentDef)
 
 export default componentDef
-

--- a/lib/matestack/ui/vue_js/components/async.js
+++ b/lib/matestack/ui/vue_js/components/async.js
@@ -5,106 +5,109 @@ import matestackEventHub from '../event_hub'
 import componentMixin from './mixin'
 
 const componentDef = {
-  mixins: [componentMixin],
-  data: function(){
-    return {
-      asyncTemplate: null,
-      showing: true,
-      loading: false,
-      hideAfterTimeout: null,
-      event: {
-        data: {}
-      }
-    }
-  },
-  methods: {
-    show: function(event_data){
-      const self = this
-      if (this.showing === true){
-        return
-      }
-      this.showing = true
-      this.event.data = event_data
-      if(this.props["defer"] != undefined){
-        if(!isNaN(this.props["defer"])){
-          this.startDefer()
-        }
-      }
-      if(this.props["hide_after"] != undefined){
-        self.hideAfterTimeout = setTimeout(function () {
-          self.hide()
-        }, parseInt(this.props["hide_after"]));
-      }
-    },
-    hide: function(){
-      this.showing = false
-      this.event.data = {}
-    },
-    startDefer: function(){
-      const self = this
-      self.loading = true;
-      setTimeout(function () {
-        self.rerender()
-      }, parseInt(this.props["defer"]));
-    },
-    rerender: function(){
-      var self = this;
-      self.loading = true;
-      axios({
-        method: "get",
-        url: location.pathname + location.search,
-        headers: {
-          'X-CSRF-Token': document.getElementsByName("csrf-token")[0].getAttribute('content')
-        },
-        params: {
-          "component_key": self.props["component_key"],
-          "component_class": self.props["parent_class"]
-        }
-      })
-      .then(function(response){
-        var tmp_dom_element = document.createElement('div');
-        tmp_dom_element.innerHTML = response['data'];
-        var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
-        self.loading = false;
-        self.asyncTemplate = template;
-      })
-      .catch(function(error){
-        console.log(error)
-        matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
-      })
-    }
-  },
-  created: function () {
-    const self = this
-    self.registerEvents(this.props['show_on'], self.show)
-    self.registerEvents(this.props['hide_on'], self.hide)
-    self.registerEvents(this.props['rerender_on'], self.rerender)
-    if(this.props["show_on"] != undefined){
-      this.showing = false
-    }
-    if(this.props["defer"] != undefined){
-      if(!isNaN(this.props["defer"])){
-        if (this.props["show_on"] == undefined){
-          this.startDefer()
-        }
-      }
-    }
-    if(this.props["init_show"] == true){
-      this.showing = true
-    }
-  },
-  beforeDestroy: function() {
-    const self = this
-    clearTimeout(self.hideAfterTimeout)
-    self.removeEvents(this.props["show_on"], self.show)
-    self.removeEvents(this.props["hide_on"], self.hide)
-    self.removeEvents(this.props["rerender_on"], self.rerender)
-  },
-  components: {
-    VRuntimeTemplate: VRuntimeTemplate
-  }
+ mixins: [componentMixin],
+ data: function(){
+   return {
+     asyncTemplate: null,
+     showing: true,
+     loading: false,
+     hideAfterTimeout: null,
+     event: {
+       data: {}
+     }
+   }
+ },
+ methods: {
+   show: function(event_data){
+     const self = this
+     if (this.showing === true){
+       return
+     }
+     this.showing = true
+     this.event.data = event_data
+     if(this.props["defer"] != undefined){
+       if(!isNaN(this.props["defer"])){
+         this.startDefer()
+       }
+     }
+     if(this.props["hide_after"] != undefined){
+       self.hideAfterTimeout = setTimeout(function () {
+         self.hide()
+       }, parseInt(this.props["hide_after"]));
+     }
+   },
+   hide: function(){
+     this.showing = false
+     this.event.data = {}
+   },
+   startDefer: function(){
+     const self = this
+     self.loading = true;
+     setTimeout(function () {
+       self.rerender()
+     }, parseInt(this.props["defer"]));
+   },
+   rerender: function(){
+     var self = this;
+     self.loading = true;
+     axios({
+       method: "get",
+       url: location.pathname + location.search,
+       headers: {
+         'X-CSRF-Token': document.getElementsByName("csrf-token")[0].getAttribute('content')
+       },
+       params: {
+         "component_key": self.props["component_key"],
+         "component_class": self.props["parent_class"]
+       }
+     })
+         .then(function(response){
+           var tmp_dom_element = document.createElement('div');
+           tmp_dom_element.innerHTML = response['data'];
+           var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
+           self.loading = false;
+           self.asyncTemplate = template;
+         })
+         .catch(function(error){
+           console.log(error)
+           matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
+         })
+   }
+ },
+ created: function () {
+   const self = this
+   self.registerEvents(this.props['show_on'], self.show)
+   self.registerEvents(this.props['hide_on'], self.hide)
+   self.registerEvents(this.props['rerender_on'], self.rerender)
+   if(this.props["show_on"] != undefined){
+     this.showing = false
+   }
+   if(this.props["defer"] != undefined){
+     if(!isNaN(this.props["defer"])){
+       if (this.props["show_on"] == undefined){
+         this.startDefer()
+       }
+     }
+   }
+   if(this.props["init_show"] == true){
+     console.log("(inside the if init show = true - it's showing !!!!!")
+     this.showing = true
+   }
+ },
+ beforeDestroy: function() {
+   const self = this
+   clearTimeout(self.hideAfterTimeout)
+   puts("%%%%% hi ")
+   self.removeEvents(this.props["show_on"], self.show)
+   self.removeEvents(this.props["hide_on"], self.hide)
+   self.removeEvents(this.props["rerender_on"], self.rerender)
+ },
+ components: {
+   VRuntimeTemplate: VRuntimeTemplate
+ }
 }
 
 let component = Vue.component('matestack-ui-core-async', componentDef)
 
 export default componentDef
+

--- a/lib/matestack/ui/vue_js/components/async.js
+++ b/lib/matestack/ui/vue_js/components/async.js
@@ -61,17 +61,17 @@ const componentDef = {
           "component_class": self.props["parent_class"]
         }
       })
-          .then(function(response){
-            var tmp_dom_element = document.createElement('div');
-            tmp_dom_element.innerHTML = response['data'];
-            var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
-            self.loading = false;
-            self.asyncTemplate = template;
-          })
-          .catch(function(error){
-            console.log(error)
-            matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
-          })
+      .then(function(response){
+        var tmp_dom_element = document.createElement('div');
+        tmp_dom_element.innerHTML = response['data'];
+        var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
+        self.loading = false;
+        self.asyncTemplate = template;
+      })
+      .catch(function(error){
+        console.log(error)
+        matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
+      })
     }
   },
   created: function () {

--- a/lib/matestack/ui/vue_js/components/async.js
+++ b/lib/matestack/ui/vue_js/components/async.js
@@ -5,106 +5,106 @@ import matestackEventHub from '../event_hub'
 import componentMixin from './mixin'
 
 const componentDef = {
- mixins: [componentMixin],
- data: function(){
-   return {
-     asyncTemplate: null,
-     showing: true,
-     loading: false,
-     hideAfterTimeout: null,
-     event: {
-       data: {}
-     }
-   }
- },
- methods: {
-   show: function(event_data){
-     const self = this
-     if (this.showing === true){
-       return
-     }
-     this.showing = true
-     this.event.data = event_data
-     if(this.props["defer"] != undefined){
-       if(!isNaN(this.props["defer"])){
-         this.startDefer()
-       }
-     }
-     if(this.props["hide_after"] != undefined){
-       self.hideAfterTimeout = setTimeout(function () {
-         self.hide()
-       }, parseInt(this.props["hide_after"]));
-     }
-   },
-   hide: function(){
-     this.showing = false
-     this.event.data = {}
-   },
-   startDefer: function(){
-     const self = this
-     self.loading = true;
-     setTimeout(function () {
-       self.rerender()
-     }, parseInt(this.props["defer"]));
-   },
-   rerender: function(){
-     var self = this;
-     self.loading = true;
-     axios({
-       method: "get",
-       url: location.pathname + location.search,
-       headers: {
-         'X-CSRF-Token': document.getElementsByName("csrf-token")[0].getAttribute('content')
-       },
-       params: {
-         "component_key": self.props["component_key"],
-         "component_class": self.props["parent_class"]
-       }
-     })
-         .then(function(response){
-           var tmp_dom_element = document.createElement('div');
-           tmp_dom_element.innerHTML = response['data'];
-           var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
-           self.loading = false;
-           self.asyncTemplate = template;
-         })
-         .catch(function(error){
-           console.log(error)
-           matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
-         })
-   }
- },
- created: function () {
-   const self = this
-   self.registerEvents(this.props['show_on'], self.show)
-   self.registerEvents(this.props['hide_on'], self.hide)
-   self.registerEvents(this.props['rerender_on'], self.rerender)
-   if(this.props["show_on"] != undefined){
-     this.showing = false
-   }
-   if(this.props["defer"] != undefined){
-     if(!isNaN(this.props["defer"])){
-       if (this.props["show_on"] == undefined){
-         this.startDefer()
-       }
-     }
-   }
-   if(this.props["init_show"] == true){
-     console.log("(inside the if init show = true - it's showing !!!!!")
-     this.showing = true
-   }
- },
- beforeDestroy: function() {
-   const self = this
-   clearTimeout(self.hideAfterTimeout)
-   puts("%%%%% hi ")
-   self.removeEvents(this.props["show_on"], self.show)
-   self.removeEvents(this.props["hide_on"], self.hide)
-   self.removeEvents(this.props["rerender_on"], self.rerender)
- },
- components: {
-   VRuntimeTemplate: VRuntimeTemplate
- }
+  mixins: [componentMixin],
+  data: function(){
+    return {
+      asyncTemplate: null,
+      showing: true,
+      loading: false,
+      hideAfterTimeout: null,
+      event: {
+        data: {}
+      }
+    }
+  },
+  methods: {
+    show: function(event_data){
+      const self = this
+      if (this.showing === true){
+        return
+      }
+      this.showing = true
+      this.event.data = event_data
+      if(this.props["defer"] != undefined){
+        if(!isNaN(this.props["defer"])){
+          this.startDefer()
+        }
+      }
+      if(this.props["hide_after"] != undefined){
+        self.hideAfterTimeout = setTimeout(function () {
+          self.hide()
+        }, parseInt(this.props["hide_after"]));
+      }
+    },
+    hide: function(){
+      this.showing = false
+      this.event.data = {}
+    },
+    startDefer: function(){
+      const self = this
+      self.loading = true;
+      setTimeout(function () {
+        self.rerender()
+      }, parseInt(this.props["defer"]));
+    },
+    rerender: function(){
+      var self = this;
+      self.loading = true;
+      axios({
+        method: "get",
+        url: location.pathname + location.search,
+        headers: {
+          'X-CSRF-Token': document.getElementsByName("csrf-token")[0].getAttribute('content')
+        },
+        params: {
+          "component_key": self.props["component_key"],
+          "component_class": self.props["parent_class"]
+        }
+      })
+          .then(function(response){
+            var tmp_dom_element = document.createElement('div');
+            tmp_dom_element.innerHTML = response['data'];
+            var template = tmp_dom_element.querySelector('#' + self.props["component_key"]).outerHTML;
+            self.loading = false;
+            self.asyncTemplate = template;
+          })
+          .catch(function(error){
+            console.log(error)
+            matestackEventHub.$emit('async_rerender_error', { id: self.props["component_key"] })
+          })
+    }
+  },
+  created: function () {
+    const self = this
+    self.registerEvents(this.props['show_on'], self.show)
+    self.registerEvents(this.props['hide_on'], self.hide)
+    self.registerEvents(this.props['rerender_on'], self.rerender)
+    if(this.props["show_on"] != undefined){
+      this.showing = false
+    }
+    if(this.props["defer"] != undefined){
+      if(!isNaN(this.props["defer"])){
+        if (this.props["show_on"] == undefined){
+          this.startDefer()
+        }
+      }
+    }
+    if(this.props["init_show"] == true){
+      console.log("(inside the if init show = true - it's showing !!!!!")
+      this.showing = true
+    }
+  },
+  beforeDestroy: function() {
+    const self = this
+    clearTimeout(self.hideAfterTimeout)
+    puts("%%%%% hi ")
+    self.removeEvents(this.props["show_on"], self.show)
+    self.removeEvents(this.props["hide_on"], self.hide)
+    self.removeEvents(this.props["rerender_on"], self.rerender)
+  },
+  components: {
+    VRuntimeTemplate: VRuntimeTemplate
+  }
 }
 
 let component = Vue.component('matestack-ui-core-async', componentDef)

--- a/lib/matestack/ui/vue_js/components/async.js
+++ b/lib/matestack/ui/vue_js/components/async.js
@@ -39,6 +39,11 @@ const componentDef = {
     hide: function(){
       this.showing = false
       this.event.data = {}
+      if(this.props["hide_after"] != undefined) {
+        this.hideAfterTimeout = setTimeout(function () {
+          this.hide()
+        }, parseInt(this.props["hide_after"]));
+      }
     },
     startDefer: function(){
       const self = this
@@ -90,14 +95,12 @@ const componentDef = {
       }
     }
     if(this.props["init_show"] == true){
-      console.log("(inside the if init show = true - it's showing !!!!!")
       this.showing = true
     }
   },
   beforeDestroy: function() {
     const self = this
     clearTimeout(self.hideAfterTimeout)
-    puts("%%%%% hi ")
     self.removeEvents(this.props["show_on"], self.show)
     self.removeEvents(this.props["hide_on"], self.hide)
     self.removeEvents(this.props["rerender_on"], self.rerender)

--- a/lib/matestack/ui/vue_js/components/toggle.js
+++ b/lib/matestack/ui/vue_js/components/toggle.js
@@ -7,7 +7,7 @@ const componentDef = {
   data: function(){
     return {
       showing: true,
-      hide_after_timeout: null,
+      hideAfterTimeout: null,
       event: {
         data: {}
       }
@@ -17,44 +17,41 @@ const componentDef = {
     show: function(event_data){
       const self = this
       if (this.showing === true){
-        console.log("showing === true")
         return
       }
       this.showing = true
       this.event.data = event_data
       if(this.props["hide_after"] != undefined){
         self.hide_after_timeout = setTimeout(function () {
-          console.log("*****")
           self.hide()
         }, parseInt(this.props["hide_after"]));
       }
     },
     hide: function(){
-      console.log(this)
-      console.log('hide function')
       this.showing = false
       this.event.data = {}
     }
   },
   created: function () {
     const self = this
+    if(this.props["hide_after"] != undefined){
+      self.hideAfterTimeout = setTimeout(function () {
+        self.hide()
+      }, parseInt(this.props["hide_after"]));
+    }
     if(this.props["show_on"] != undefined){
-      console.log("show_on")
       this.showing = false
       var show_events = this.props["show_on"].split(",")
       show_events.forEach(show_event => matestackEventHub.$on(show_event.trim(), self.show));
     }
     if(this.props["hide_on"] != undefined){
-      console.log("hide_on")
       var hide_events = this.props["hide_on"].split(",")
       hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
     }
     if(this.props["hide_after"] != undefined){
-      console.log("hide_after")
       this.showing = false
     }
     if(this.props["init_show"] == true){
-      console.log("init_show")
       this.showing = true
     }
   },

--- a/lib/matestack/ui/vue_js/components/toggle.js
+++ b/lib/matestack/ui/vue_js/components/toggle.js
@@ -3,76 +3,76 @@ import matestackEventHub from '../event_hub'
 import componentMixin from './mixin'
 
 const componentDef = {
- mixins: [componentMixin],
- data: function(){
-   return {
-     showing: true,
-     hide_after_timeout: null,
-     event: {
-       data: {}
-     }
-   }
- },
- methods: {
-   show: function(event_data){
-     const self = this
-     if (this.showing === true){
-       console.log("showing === true")
-       return
-     }
-     this.showing = true
-     this.event.data = event_data
-     if(this.props["hide_after"] != undefined){
-       self.hide_after_timeout = setTimeout(function () {
-         console.log("*****")
-         self.hide()
-       }, parseInt(this.props["hide_after"]));
-     }
-   },
-   hide: function(){
-     console.log(this)
-     console.log('hide function')
-     this.showing = false
-     this.event.data = {}
-   }
- },
- created: function () {
-   const self = this
-   if(this.props["show_on"] != undefined){
-     console.log("show_on")
-     this.showing = false
-     var show_events = this.props["show_on"].split(",")
-     show_events.forEach(show_event => matestackEventHub.$on(show_event.trim(), self.show));
-   }
-   if(this.props["hide_on"] != undefined){
-     console.log("hide_on")
-     var hide_events = this.props["hide_on"].split(",")
-     hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
-   }
-   if(this.props["hide_after"] != undefined){
-     console.log("hide_after")
-     this.showing = false
-   }
-   if(this.props["init_show"] == true){
-     console.log("init_show")
-     this.showing = true
-   }
- },
- beforeDestroy: function() {
-   const self = this
-   clearTimeout(self.hide_after_timeout)
-   matestackEventHub.$off(this.props["show_on"], self.show);
-   matestackEventHub.$off(this.props["hide_on"], self.hide);
-   if(this.props["show_on"] != undefined){
-     var shown_events = this.props["show_on"].split(",")
-     shown_events.forEach(show_event => matestackEventHub.$off(show_event.trim(), self.show));
-   }
-   if(this.props["hide_on"] != undefined){
-     var hiden_events = this.props["hide_on"].split(",")
-     hiden_events.forEach(hide_event => matestackEventHub.$off(hide_event.trim(), self.hide));
-   }
- },
-}
+  mixins: [componentMixin],
+  data: function(){
+    return {
+      showing: true,
+      hide_after_timeout: null,
+      event: {
+        data: {}
+      }
+    }
+  },
+  methods: {
+    show: function(event_data){
+      const self = this
+      if (this.showing === true){
+        console.log("showing === true")
+        return
+      }
+      this.showing = true
+      this.event.data = event_data
+      if(this.props["hide_after"] != undefined){
+        self.hide_after_timeout = setTimeout(function () {
+          console.log("*****")
+          self.hide()
+        }, parseInt(this.props["hide_after"]));
+      }
+    },
+    hide: function(){
+      console.log(this)
+      console.log('hide function')
+      this.showing = false
+      this.event.data = {}
+    }
+  },
+  created: function () {
+    const self = this
+    if(this.props["show_on"] != undefined){
+      console.log("show_on")
+      this.showing = false
+      var show_events = this.props["show_on"].split(",")
+      show_events.forEach(show_event => matestackEventHub.$on(show_event.trim(), self.show));
+    }
+    if(this.props["hide_on"] != undefined){
+      console.log("hide_on")
+      var hide_events = this.props["hide_on"].split(",")
+      hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
+    }
+    if(this.props["hide_after"] != undefined){
+      console.log("hide_after")
+      this.showing = false
+    }
+    if(this.props["init_show"] == true){
+      console.log("init_show")
+      this.showing = true
+    }
+  },
+  beforeDestroy: function() {
+    const self = this
+    clearTimeout(self.hide_after_timeout)
+    matestackEventHub.$off(this.props["show_on"], self.show);
+    matestackEventHub.$off(this.props["hide_on"], self.hide);
+    if(this.props["show_on"] != undefined){
+      var shown_events = this.props["show_on"].split(",")
+      shown_events.forEach(show_event => matestackEventHub.$off(show_event.trim(), self.show));
+    }
+    if(this.props["hide_on"] != undefined){
+      var hiden_events = this.props["hide_on"].split(",")
+      hiden_events.forEach(hide_event => matestackEventHub.$off(hide_event.trim(), self.hide));
+    }
+  },
+  }
 
 let component = Vue.component('matestack-ui-core-toggle', componentDef)
 

--- a/lib/matestack/ui/vue_js/components/toggle.js
+++ b/lib/matestack/ui/vue_js/components/toggle.js
@@ -48,7 +48,7 @@ const componentDef = {
       var hide_events = this.props["hide_on"].split(",")
       hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
     }
-    if(this.props["hide_after"] != undefined){
+    if(this.props["show_on"] != undefined){
       this.showing = false
     }
     if(this.props["init_show"] == true){

--- a/lib/matestack/ui/vue_js/components/toggle.js
+++ b/lib/matestack/ui/vue_js/components/toggle.js
@@ -3,67 +3,75 @@ import matestackEventHub from '../event_hub'
 import componentMixin from './mixin'
 
 const componentDef = {
-  mixins: [componentMixin],
-  data: function(){
-    return {
-      showing: true,
-      hide_after_timeout: null,
-      event: {
-        data: {}
-      }
-    }
-  },
-  methods: {
-    show: function(event_data){
-      const self = this
-      if (this.showing === true){
-        return
-      }
-      this.showing = true
-      this.event.data = event_data
-      if(this.props["hide_after"] != undefined){
-        self.hide_after_timeout = setTimeout(function () {
-          self.hide()
-        }, parseInt(this.props["hide_after"]));
-      }
-    },
-    hide: function(){
-      this.showing = false
-      this.event.data = {}
-    }
-  },
-  created: function () {
-    const self = this
-    if(this.props["show_on"] != undefined){
-      this.showing = false
-      var show_events = this.props["show_on"].split(",")
-      show_events.forEach(show_event => matestackEventHub.$on(show_event.trim(), self.show));
-    }
-    if(this.props["hide_on"] != undefined){
-      var hide_events = this.props["hide_on"].split(",")
-      hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
-    }
-    if(this.props["show_on"] != undefined){
-      this.showing = false
-    }
-    if(this.props["init_show"] == true){
-      this.showing = true
-    }
-  },
-  beforeDestroy: function() {
-    const self = this
-    clearTimeout(self.hide_after_timeout)
-    matestackEventHub.$off(this.props["show_on"], self.show);
-    matestackEventHub.$off(this.props["hide_on"], self.hide);
-    if(this.props["show_on"] != undefined){
-      var shown_events = this.props["show_on"].split(",")
-      shown_events.forEach(show_event => matestackEventHub.$off(show_event.trim(), self.show));
-    }
-    if(this.props["hide_on"] != undefined){
-      var hiden_events = this.props["hide_on"].split(",")
-      hiden_events.forEach(hide_event => matestackEventHub.$off(hide_event.trim(), self.hide));
-    }
-  },
+ mixins: [componentMixin],
+ data: function(){
+   return {
+     showing: true,
+     hide_after_timeout: null,
+     event: {
+       data: {}
+     }
+   }
+ },
+ methods: {
+   show: function(event_data){
+     const self = this
+     if (this.showing === true){
+       console.log("showing === true")
+       return
+     }
+     this.showing = true
+     this.event.data = event_data
+     if(this.props["hide_after"] != undefined){
+       self.hide_after_timeout = setTimeout(function () {
+         console.log("*****")
+         self.hide()
+       }, parseInt(this.props["hide_after"]));
+     }
+   },
+   hide: function(){
+     console.log(this)
+     console.log('hide function')
+     this.showing = false
+     this.event.data = {}
+   }
+ },
+ created: function () {
+   const self = this
+   if(this.props["show_on"] != undefined){
+     console.log("show_on")
+     this.showing = false
+     var show_events = this.props["show_on"].split(",")
+     show_events.forEach(show_event => matestackEventHub.$on(show_event.trim(), self.show));
+   }
+   if(this.props["hide_on"] != undefined){
+     console.log("hide_on")
+     var hide_events = this.props["hide_on"].split(",")
+     hide_events.forEach(hide_event => matestackEventHub.$on(hide_event.trim(), self.hide));
+   }
+   if(this.props["hide_after"] != undefined){
+     console.log("hide_after")
+     this.showing = false
+   }
+   if(this.props["init_show"] == true){
+     console.log("init_show")
+     this.showing = true
+   }
+ },
+ beforeDestroy: function() {
+   const self = this
+   clearTimeout(self.hide_after_timeout)
+   matestackEventHub.$off(this.props["show_on"], self.show);
+   matestackEventHub.$off(this.props["hide_on"], self.hide);
+   if(this.props["show_on"] != undefined){
+     var shown_events = this.props["show_on"].split(",")
+     shown_events.forEach(show_event => matestackEventHub.$off(show_event.trim(), self.show));
+   }
+   if(this.props["hide_on"] != undefined){
+     var hiden_events = this.props["hide_on"].split(",")
+     hiden_events.forEach(hide_event => matestackEventHub.$off(hide_event.trim(), self.hide));
+   }
+ },
 }
 
 let component = Vue.component('matestack-ui-core-toggle', componentDef)

--- a/lib/matestack/ui/vue_js/components/toggle.js
+++ b/lib/matestack/ui/vue_js/components/toggle.js
@@ -72,7 +72,7 @@ const componentDef = {
       hiden_events.forEach(hide_event => matestackEventHub.$off(hide_event.trim(), self.hide));
     }
   },
-  }
+}
 
 let component = Vue.component('matestack-ui-core-toggle', componentDef)
 

--- a/lib/matestack/ui/vue_js/components/toggle.rb
+++ b/lib/matestack/ui/vue_js/components/toggle.rb
@@ -14,12 +14,10 @@ module Matestack
           end
 
           def toggle_attributes
-            a = options.merge({
-                                class: "matestack-toggle-component-root",
-                                'v-if': 'showing'
-                              })
-            puts("**** #{a} !!!!")
-            a
+            options.merge({
+              class: "matestack-toggle-component-root",
+              'v-if': 'showing'
+            })
           end
 
           protected
@@ -32,9 +30,9 @@ module Matestack
               init_show: ctx.init_show,
             }
           end
- 
+
         end
       end
     end
   end
- end
+end

--- a/lib/matestack/ui/vue_js/components/toggle.rb
+++ b/lib/matestack/ui/vue_js/components/toggle.rb
@@ -4,15 +4,15 @@ module Matestack
       module Components
         class Toggle < Matestack::Ui::VueJs::Vue
           vue_name 'matestack-ui-core-toggle'
- 
+
           optional :show_on, :hide_on, :hide_after, :init_show
- 
+
           def response
             div toggle_attributes do
               yield
             end
           end
- 
+
           def toggle_attributes
             a = options.merge({
                                 class: "matestack-toggle-component-root",
@@ -21,9 +21,9 @@ module Matestack
             puts("**** #{a} !!!!")
             a
           end
- 
+
           protected
- 
+
           def vue_props
             {
               show_on: ctx.show_on,
@@ -38,4 +38,3 @@ module Matestack
     end
   end
  end
- 

--- a/lib/matestack/ui/vue_js/components/toggle.rb
+++ b/lib/matestack/ui/vue_js/components/toggle.rb
@@ -4,24 +4,26 @@ module Matestack
       module Components
         class Toggle < Matestack::Ui::VueJs::Vue
           vue_name 'matestack-ui-core-toggle'
-
+ 
           optional :show_on, :hide_on, :hide_after, :init_show
-
+ 
           def response
             div toggle_attributes do
               yield
             end
           end
-
+ 
           def toggle_attributes
-            options.merge({
-              class: "matestack-toggle-component-root", 
-              'v-if': 'showing'
-            })
+            a = options.merge({
+                                class: "matestack-toggle-component-root",
+                                'v-if': 'showing'
+                              })
+            puts("**** #{a} !!!!")
+            a
           end
-
+ 
           protected
-
+ 
           def vue_props
             {
               show_on: ctx.show_on,
@@ -30,9 +32,10 @@ module Matestack
               init_show: ctx.init_show,
             }
           end
-
+ 
         end
       end
     end
   end
-end
+ end
+ 

--- a/lib/matestack/ui/vue_js/components/toggle.rb
+++ b/lib/matestack/ui/vue_js/components/toggle.rb
@@ -15,7 +15,7 @@ module Matestack
 
           def toggle_attributes
             options.merge({
-              class: "matestack-toggle-component-root",
+              class: "matestack-toggle-component-root", 
               'v-if': 'showing'
             })
           end

--- a/spec/dummy/app/matestack/demo/components/header.rb
+++ b/spec/dummy/app/matestack/demo/components/header.rb
@@ -11,4 +11,4 @@ class Demo::Components::Header < ApplicationComponent
     isolate_test rerender_on: 'isolate', public_options: { foo: :bar }
   end
 
- end 
+end

--- a/spec/dummy/app/matestack/demo/components/header.rb
+++ b/spec/dummy/app/matestack/demo/components/header.rb
@@ -1,7 +1,7 @@
 class Demo::Components::Header < ApplicationComponent
 
   optional :user
- 
+
   def response
     toggle hide_after: 3000 do
       div do
@@ -10,6 +10,5 @@ class Demo::Components::Header < ApplicationComponent
     end
     isolate_test rerender_on: 'isolate', public_options: { foo: :bar }
   end
- 
- end
- 
+
+ end 

--- a/spec/dummy/app/matestack/demo/components/header.rb
+++ b/spec/dummy/app/matestack/demo/components/header.rb
@@ -1,19 +1,15 @@
 class Demo::Components::Header < ApplicationComponent
 
   optional :user
-
+ 
   def response
-    h1 'This is a header'
-    [1,2].each do |number|
-      slot :first, number
-    end
-    slot :user
-    toggle show_on: 'show', hide_on: 'hide' do
+    toggle hide_after: 3000 do
       div do
-        h2 ctx.user
+        h2 'THIS SHOULD HIDE AFTER 3 SECONDS'
       end
     end
     isolate_test rerender_on: 'isolate', public_options: { foo: :bar }
   end
-
-end
+ 
+ end
+ 


### PR DESCRIPTION
## Issue https://github.com/matestack/matestack-ui-core/issues/549: `hide_after` should work without `show_on: 'event'`

Hi! As you can see, this PR only consists of a bunch of console.logs and puts. I did this to show where I was looking for the bug/solution and to potentially get a hint on where to start. I was (obviously) unsuccessful, but I am hoping that I was looking at the correct lines or at least in the right files. 

I understand that the issue comes from the mount as it says in the description of the bug (the lifecycle is never started, therefore the timer also never starts), but knowing that it comes from a vue.js file, I could not figure out what to do. 