### PR TITLE
fix(select component): fix rendering of placeholder

### DIFF
--- a/lib/matestack/ui/vue_js/components/form/select.rb
+++ b/lib/matestack/ui/vue_js/components/form/select.rb
@@ -18,7 +18,7 @@ module Matestack
 
             def render_options
               if placeholder
-                option value: nil, disabled: true, selected: init_value.nil?, text: placeholder
+                option value: '', disabled: true, selected: init_value.nil?, text: placeholder
               end
               select_options.to_a.each do |item|
                 option item_label(item), value: item_value(item), disabled: item_disabled?(item)


### PR DESCRIPTION
Make the value property render in the HTML option element used as a placeholder

re #573

Seems to be no **develop** branch

## [Issue 573](https://github.com/matestack/matestack-ui-core/issues/573): `select` placeholder not rendered properly

### Changes

- Changed `value: nil` in the `option` to `value: ''`. This should make the HTML render the property and display the placeholder

### Notes

- First PR to this awesome project :)
