### PR TITLE
Update README for 4.0.0.beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v4.0.0.beta1 Release - 2026-03-23
+
+### Breaking Changes
+
+- **Rails >= 8.0 required** (dropped support for Rails 5.2, 6.x, 7.x)
+- **Ruby >= 3.2 required** (dropped support for Ruby 2.6, 2.7, 3.0, 3.1)
+- Removed webpacker support; asset pipeline now uses propshaft
+- Removed legacy multi-version application config files (`application.5.2_rb`, etc.)
+- Removed webpack config files
+
+### Improvements
+
+- Full compatibility with Rails 8.1 and Ruby 3.4
+- CI migrated from Docker Compose to native GitHub Actions (Ruby 3.4, Postgres 16)
+
 ## v3.0.1 Release - 2022-04-29
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -10,20 +10,19 @@
 
 Boost your productivity & easily create component based web UIs in pure Ruby.
 
-`matestack-ui-core` enables you to craft maintainable web UIs in pure Ruby, skipping ERB and HTML. UI code becomes a native and fun part of your Rails app. `matestack-ui-core` can progressively replace the classic Rails-View-Layer. You are able to use
-it alongside your classic views.
+`matestack-ui-core` enables you to craft maintainable web UIs in pure Ruby, skipping ERB and HTML. UI code becomes a native and fun part of your Rails app. `matestack-ui-core` can progressively replace the classic Rails-View-Layer. You are able to use it alongside your classic views.
+
+> **Note:** Version 4.0.0 is a pre-release (`4.0.0.beta1`) targeting Rails 8 and Ruby 3.2+. If you are on an older Rails/Ruby version, use the `3.x` release series.
 
 ## Compatibility
 
-`matestack-ui-core` is tested against:
+`matestack-ui-core` 4.x is tested against:
 
-- Rails 7.0.1 + Ruby 3.0.0
-- Rails 6.1.1 + Ruby 3.0.0
-- Rails 6.1.1 + Ruby 2.7.2
-- Rails 6.0.3.4 + Ruby 2.6.6
-- Rails 5.2.4.4 + Ruby 2.6.6
+- Rails 8.1 + Ruby 3.4
 
-Rails versions below 5.2 are not supported.
+**Requirements:** Rails >= 8.0, Ruby >= 3.2
+
+For older Rails/Ruby versions, use `matestack-ui-core` 3.x.
 
 ## Documentation/Installation
 


### PR DESCRIPTION
Update compatibility section to reflect Rails 8 / Ruby 3.2+ requirements and note the pre-release status. Remove stale Rails 5.2-7.0 / Ruby 2.6-3.0 entries.